### PR TITLE
Add 'config.include Capybara::DSL' to fix undefined method 'visit' error

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  config.include Capybara::DSL
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
Changes proposed in this pull request:  
- Add line to rails helper to address RSPEC undefined method 'visit' error


@adam-conway @anubiskhan @vadlusk @agpiermarini   
