### PR TITLE
Adding accessories index (aka /bike-shop)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 .byebug_history
 /db/csv
 /coverage
+/db/schema.rb

--- a/app/controllers/accessories_controller.rb
+++ b/app/controllers/accessories_controller.rb
@@ -3,4 +3,8 @@ class AccessoriesController < ApplicationController
     @accessory = Accessory.find(params[:id])
     @active = @accessory.active?
   end
+
+  def index
+    @accessories = Accessory.where(status: 'active')
+  end
 end

--- a/app/views/accessories/index.html.erb
+++ b/app/views/accessories/index.html.erb
@@ -1,0 +1,7 @@
+<% @accessories.each do |accessory| %>
+  <%= accessory.title %>
+  <%= accessory.description %>
+  <%= accessory.price %>
+  <img src="<%= accessory.image_url %>" alt="" class="accessory_image">
+  <%= button_to 'Add to Cart' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resources :conditions, only: %i[index show]
   resources :stations, only: [:index, :show], param: :slug
   resources :accessories, only: [:show]
+  get '/bike-shop', to: 'accessories#index'
 
   root controller: 'welcome', action: :index
 

--- a/spec/factories/accessories.rb
+++ b/spec/factories/accessories.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     sequence(:description) { ['Can to make your back tire sound like a motorcycle', 'Bell that rings like the heavens itself', 'Headlight brighter than a thousand supernovas'].sample }
     price { rand(0.00..1000.00) }
     image_url { "http://icons.iconarchive.com/icons/guillendesign/variations-3/256/Default-Icon-icon.png" }
+    status { 0 }
   end
 end

--- a/spec/features/visitor/accessories/user_sees_accessory_index_spec.rb
+++ b/spec/features/visitor/accessories/user_sees_accessory_index_spec.rb
@@ -4,7 +4,7 @@ describe 'visitor' do
   scenario 'a visitor goes to /bike-shop and sees all accessories' do
     accessories = create_list(:accessory, 12)
 
-    visit accessories_path
+    visit '/bike-shop'
 
     accessories.each do |accessory|
       expect(page).to have_content(accessory.title)

--- a/spec/features/visitor/accessories/user_sees_accessory_index_spec.rb
+++ b/spec/features/visitor/accessories/user_sees_accessory_index_spec.rb
@@ -5,7 +5,6 @@ describe 'visitor' do
     accessories = create_list(:accessory, 12)
 
     visit '/bike-shop'
-    save_and_open_page
 
     accessories.each do |accessory|
       expect(page).to have_content(accessory.title)

--- a/spec/features/visitor/accessories/user_sees_accessory_index_spec.rb
+++ b/spec/features/visitor/accessories/user_sees_accessory_index_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe 'visitor' do
+  scenario 'a visitor goes to /bike-shop and sees all accessories' do
+    accessories = create_list(:accessory, 12)
+
+    visit accessories_path
+
+    accessories.each do |accessory|
+      expect(page).to have_content(accessory.title)
+      expect(page).to have_content(accessory.description)
+      expect(page).to have_content(accessory.price)
+      expect(page).to have_css(".accessory_image")
+    end
+  end
+end

--- a/spec/features/visitor/accessories/user_sees_accessory_index_spec.rb
+++ b/spec/features/visitor/accessories/user_sees_accessory_index_spec.rb
@@ -5,12 +5,14 @@ describe 'visitor' do
     accessories = create_list(:accessory, 12)
 
     visit '/bike-shop'
+    save_and_open_page
 
     accessories.each do |accessory|
       expect(page).to have_content(accessory.title)
       expect(page).to have_content(accessory.description)
       expect(page).to have_content(accessory.price)
       expect(page).to have_css(".accessory_image")
+      expect(page).to have_button("Add to Cart")
     end
   end
 end


### PR DESCRIPTION
Changes proposed in this pull request:  
- Adds '/bike-shop' which points to accessory#index
- The accessory index index page has a 'button_to' for adding to cart, however cart functionality is currently being worked on by someone else, so this will be added in when that's done. 


@adam-conway @anubiskhan @vadlusk @agpiermarini   
connect to #2 