### PR TITLE
Adding remove to cart/adam c

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -13,4 +13,12 @@ class CartsController < ApplicationController
     flash[:success] = "You've added #{pluralize(session[:cart][accessory.id.to_s], accessory.title)} to your cart"
     redirect_to bike_shop_path
   end
+
+  def destroy
+    accessory = Accessory.find(params[:accessory_id])
+
+    @cart.remove_accessory(params[:accessory_id])
+    flash[:success] = %Q(Successfully removed #{view_context.link_to(accessory.title, accessory_path(accessory))} from your cart)
+    redirect_to '/cart'
+  end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -13,6 +13,10 @@ class Cart
     end
   end
 
+  def remove_accessory(id)
+    @contents.delete(id)
+  end
+
   def total_item_count
     contents.values.sum
   end

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -3,7 +3,9 @@
   <%= number_to_currency(accessory.price) %>
   <img src="<%= accessory.image_url %>" alt="" class="accessory_image">
   <%= @cart.contents[accessory.id.to_s] %>
+  <%= link_to "Remove", cart_path(@cart, accessory_id: accessory.id), method: :delete %>
 <% end %>
+
 <h3>Subtotal</h3>
 <% @accessories.each do |accessory| %>
   <p><%= number_to_currency(accessory.price) %> x <%= @cart.contents[accessory.id.to_s] %> =

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <div id="notice">
       <% flash.each do |key, value| %>
         <div class=" <%= flash_class(key) %> ">
-          <%= value %>
+          <%= value.html_safe %>
         </div>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :carts, only: %i[create]
+  resources :carts, only: [:create, :destroy]
   resources :trips, only: [:index, :show]
   resources :conditions, only: %i[index show]
   resources :stations, only: [:index, :show], param: :slug

--- a/spec/features/visitor/cart/visitor_can_use_cart_spec.rb
+++ b/spec/features/visitor/cart/visitor_can_use_cart_spec.rb
@@ -29,7 +29,7 @@ describe 'Visitor' do
         click_button("Add to Cart")
       end
 
-      visit cart_path
+      visit '/cart'
 
       accessories.each do |accessory|
         expect(page).to have_content(accessory.title)
@@ -74,7 +74,7 @@ describe 'Visitor' do
       fill_in 'user[password]', with: "password"
       fill_in 'user[password_confirmation]', with: "password"
 
-      visit cart_path
+      visit '/cart'
 
       accessories.each do |accessory|
         expect(page).to have_content(accessory.title)

--- a/spec/features/visitor/cart/visitor_can_use_cart_spec.rb
+++ b/spec/features/visitor/cart/visitor_can_use_cart_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 describe 'Visitor' do
   context 'a visitor goes to the cart page' do
     it 'displays all added accessories' do
-      # accessories = create_list(:accessory, 5)
-
       accessory1 = Accessory.create!(title: "help", description: "Bad", price: 10, image_url: "http://icons.iconarchive.com/icons/guillendesign/variations-3/256/Default-Icon-icon.png", status: 0)
       accessory2 = Accessory.create!(title: "help", description: "Bad", price: 10, image_url: "http://icons.iconarchive.com/icons/guillendesign/variations-3/256/Default-Icon-icon.png", status: 0)
       accessory3 = Accessory.create!(title: "help", description: "Bad", price: 10, image_url: "http://icons.iconarchive.com/icons/guillendesign/variations-3/256/Default-Icon-icon.png", status: 0)

--- a/spec/features/visitor/cart/visitor_removes_item_from_cart_spec.rb
+++ b/spec/features/visitor/cart/visitor_removes_item_from_cart_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+# require './models/cart'
+
+describe 'Visitor' do
+  context 'a visitor goes to the cart page' do
+    it 'removes item from cart' do
+      accessories = create_list(:accessory, 5)
+      
+      visit bike_shop_path
+      2.times do
+        within('form:nth-of-type(1)') do
+          click_button("Add to Cart")
+        end
+      end
+
+      visit cart_path
+
+      click_button("Remove")
+
+      expect(page).to have_content("Successfully removed #{accessories[0].name} from your cart")
+      expect(page).to_not have_content(accessory.name)
+
+      click_button("#{accessories[0].name}")
+
+      expect(path).to eq(accessory_path(accessories[0]))
+    end
+  end
+
+end

--- a/spec/features/visitor/cart/visitor_removes_item_from_cart_spec.rb
+++ b/spec/features/visitor/cart/visitor_removes_item_from_cart_spec.rb
@@ -5,7 +5,7 @@ describe 'Visitor' do
   context 'a visitor goes to the cart page' do
     it 'removes item from cart' do
       accessories = create_list(:accessory, 5)
-      
+
       visit bike_shop_path
       2.times do
         within('form:nth-of-type(1)') do
@@ -13,16 +13,16 @@ describe 'Visitor' do
         end
       end
 
-      visit cart_path
+      visit '/cart'
 
-      click_button("Remove")
+      click_on("Remove")
 
-      expect(page).to have_content("Successfully removed #{accessories[0].name} from your cart")
-      expect(page).to_not have_content(accessory.name)
+      expect(page).to have_content("Successfully removed #{accessories[0].title} from your cart")
+      expect(page).to_not have_content(accessories[0].description)
 
-      click_button("#{accessories[0].name}")
+      click_on("#{accessories[0].title}")
 
-      expect(path).to eq(accessory_path(accessories[0]))
+      expect(current_path).to eq(accessory_path(accessories[0]))
     end
   end
 


### PR DESCRIPTION
Changes proposed in this pull request:  
- This adds a remove button to the cart show page
- That button removes that item entirely from the cart
- The flash message includes a link to the accessory show page for the accessory that was deleted


@adam-conway @anubiskhan @vadlusk @agpiermarini   
