### PR TITLE
Build truncated csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,5 @@
 /yarn-error.log
 
 .byebug_history
-/db/csv
 /coverage
 /db/schema.rb

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@
 /yarn-error.log
 
 .byebug_history
+/db/csv
 /coverage
 /db/schema.rb

--- a/db/csv/trip-trunc.csv
+++ b/db/csv/trip-trunc.csv
@@ -1,0 +1,1000 @@
+id,duration,start_date,start_station_name,start_station_id,end_date,end_station_name,end_station_id,bike_id,subscription_type,zip_code
+4607,70,8/29/2013 14:42,San Jose City Hall,10,8/29/2013 14:43,San Jose City Hall,10,661,Subscriber,95138
+4130,71,8/29/2013 10:16,Mountain View City Hall,27,8/29/2013 10:17,Mountain View City Hall,27,48,Subscriber,97214
+4251,77,8/29/2013 11:29,San Jose City Hall,10,8/29/2013 11:30,San Jose City Hall,10,26,Subscriber,95060
+4299,83,8/29/2013 12:02,South Van Ness at Market,66,8/29/2013 12:04,Market at 10th,67,319,Subscriber,94103
+4927,103,8/29/2013 18:54,Golden Gate at Polk,59,8/29/2013 18:56,Golden Gate at Polk,59,527,Subscriber,94109
+4500,109,8/29/2013 13:25,Santa Clara at Almaden,4,8/29/2013 13:27,Adobe on Almaden,5,679,Subscriber,95112
+4563,111,8/29/2013 14:02,San Salvador at 1st,8,8/29/2013 14:04,San Salvador at 1st,8,687,Subscriber,95112
+4760,113,8/29/2013 17:01,South Van Ness at Market,66,8/29/2013 17:03,South Van Ness at Market,66,553,Subscriber,94103
+4258,114,8/29/2013 11:33,San Jose City Hall,10,8/29/2013 11:35,MLK Library,11,107,Subscriber,95060
+4549,125,8/29/2013 13:52,Spear at Folsom,49,8/29/2013 13:55,Embarcadero at Bryant,54,368,Subscriber,94109
+4498,126,8/29/2013 13:23,San Pedro Square,6,8/29/2013 13:25,Santa Clara at Almaden,4,26,Subscriber,95112
+4965,129,8/29/2013 19:32,Mountain View Caltrain Station,28,8/29/2013 19:35,Mountain View Caltrain Station,28,140,Subscriber,94041
+4557,130,8/29/2013 13:57,2nd at South Park,64,8/29/2013 13:59,2nd at South Park,64,371,Subscriber,94122
+4386,134,8/29/2013 12:31,Clay at Battery,41,8/29/2013 12:33,Beale at Market,56,503,Subscriber,94109
+4749,138,8/29/2013 16:57,Post at Kearney,47,8/29/2013 16:59,Post at Kearney,47,408,Subscriber,94117
+4242,141,8/29/2013 11:25,San Jose City Hall,10,8/29/2013 11:27,San Jose City Hall,10,26,Subscriber,95060
+4329,142,8/29/2013 12:11,Market at 10th,67,8/29/2013 12:14,Market at 10th,67,319,Subscriber,94103
+5097,142,8/29/2013 22:21,Steuart at Market,74,8/29/2013 22:24,Harry Bridges Plaza (Ferry Building),50,564,Subscriber,94115
+5084,144,8/29/2013 22:06,Powell Street BART,39,8/29/2013 22:08,Market at 4th,76,574,Subscriber,94115
+4982,146,8/29/2013 19:42,Spear at Folsom,49,8/29/2013 19:44,Embarcadero at Bryant,54,542,Subscriber,94105
+4417,148,8/29/2013 12:45,Redwood City Caltrain Station,22,8/29/2013 12:48,Redwood City Caltrain Station,22,159,Subscriber,94061
+4265,151,8/29/2013 11:40,San Francisco City Hall,58,8/29/2013 11:42,San Francisco City Hall,58,520,Subscriber,94110
+5093,160,8/29/2013 22:12,Post at Kearney,47,8/29/2013 22:14,Market at Sansome,77,442,Subscriber,94115
+4168,161,8/29/2013 10:56,Beale at Market,56,8/29/2013 10:59,Steuart at Market,74,414,Customer,94117
+4550,163,8/29/2013 13:53,Japantown,9,8/29/2013 13:56,Japantown,9,684,Subscriber,95112
+4533,165,8/29/2013 13:43,Temporary Transbay Terminal (Howard at Beale),55,8/29/2013 13:46,Embarcadero at Folsom,51,365,Subscriber,94109
+4510,166,8/29/2013 13:31,San Jose Civic Center,3,8/29/2013 13:34,San Salvador at 1st,8,661,Subscriber,95112
+5070,168,8/29/2013 21:43,South Van Ness at Market,66,8/29/2013 21:46,South Van Ness at Market,66,598,Subscriber,94115
+4917,169,8/29/2013 18:45,Redwood City Medical Center,26,8/29/2013 18:48,Broadway at Main,25,229,Subscriber,94041
+4276,173,8/29/2013 11:45,2nd at Townsend,61,8/29/2013 11:48,2nd at South Park,64,280,Customer,95819
+4378,173,8/29/2013 12:27,Civic Center BART (7th at Market),72,8/29/2013 12:30,Civic Center BART (7th at Market),72,374,Subscriber,94110
+4069,174,8/29/2013 9:08,2nd at South Park,64,8/29/2013 9:11,2nd at South Park,64,288,Subscriber,94114
+4625,175,8/29/2013 15:02,San Francisco City Hall,58,8/29/2013 15:05,South Van Ness at Market,66,267,Subscriber,94115
+4086,178,8/29/2013 9:42,Commercial at Montgomery,45,8/29/2013 9:45,Commercial at Montgomery,45,379,Subscriber,94402
+5088,183,8/29/2013 22:08,Market at 4th,76,8/29/2013 22:12,Post at Kearney,47,309,Subscriber,94115
+4721,184,8/29/2013 16:27,Market at 10th,67,8/29/2013 16:30,South Van Ness at Market,66,416,Subscriber,94107
+4636,186,8/29/2013 15:11,2nd at Folsom,62,8/29/2013 15:14,2nd at Townsend,61,366,Subscriber,94109
+4812,186,8/29/2013 17:30,2nd at Folsom,62,8/29/2013 17:33,2nd at Folsom,62,409,Subscriber,94107
+4720,188,8/29/2013 16:27,Market at 10th,67,8/29/2013 16:30,South Van Ness at Market,66,379,Subscriber,94109
+4798,188,8/29/2013 17:22,Powell Street BART,39,8/29/2013 17:25,Market at 4th,76,429,Subscriber,94102
+4944,188,8/29/2013 19:06,Clay at Battery,41,8/29/2013 19:10,Washington at Kearney,46,502,Customer,94612
+4400,189,8/29/2013 12:39,Washington at Kearney,46,8/29/2013 12:42,Clay at Battery,41,619,Subscriber,94609
+4606,191,8/29/2013 14:38,San Jose City Hall,10,8/29/2013 14:42,San Jose City Hall,10,35,Subscriber,95138
+4705,193,8/29/2013 16:15,Golden Gate at Polk,59,8/29/2013 16:18,San Francisco City Hall,58,519,Subscriber,94107
+4841,197,8/29/2013 17:48,University and Emerson,35,8/29/2013 17:51,Cowper at University,37,83,Subscriber,94107
+4704,204,8/29/2013 16:15,Golden Gate at Polk,59,8/29/2013 16:18,San Francisco City Hall,58,316,Subscriber,94109
+4824,207,8/29/2013 17:38,Market at 10th,67,8/29/2013 17:42,South Van Ness at Market,66,632,Subscriber,94103
+4854,209,8/29/2013 17:57,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 18:00,5th at Howard,57,348,Customer,94158
+4502,210,8/29/2013 13:28,Adobe on Almaden,5,8/29/2013 13:31,San Jose Civic Center,3,664,Subscriber,95112
+4638,211,8/29/2013 15:17,Steuart at Market,74,8/29/2013 15:21,Harry Bridges Plaza (Ferry Building),50,634,Subscriber,94123
+4855,214,8/29/2013 17:57,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 18:00,5th at Howard,57,334,Customer,94158
+4994,214,8/29/2013 19:54,Powell at Post (Union Square),71,8/29/2013 19:57,Market at 4th,76,528,Subscriber,94109
+4459,215,8/29/2013 13:08,Market at 10th,67,8/29/2013 13:11,Civic Center BART (7th at Market),72,319,Subscriber,94114
+5074,216,8/29/2013 21:45,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 21:49,San Francisco Caltrain 2 (330 Townsend),69,268,Subscriber,94133
+4081,218,8/29/2013 9:38,Mountain View City Hall,27,8/29/2013 9:41,Mountain View City Hall,27,150,Subscriber,97214
+4337,219,8/29/2013 12:13,Grant Avenue at Columbus Avenue,73,8/29/2013 12:16,Commercial at Montgomery,45,506,Subscriber,94109
+4401,222,8/29/2013 12:39,Embarcadero at Vallejo,48,8/29/2013 12:43,Harry Bridges Plaza (Ferry Building),50,613,Subscriber,94123
+4411,223,8/29/2013 12:40,2nd at Townsend,61,8/29/2013 12:43,San Francisco Caltrain 2 (330 Townsend),69,259,Subscriber,94117
+4467,225,8/29/2013 13:11,Mechanics Plaza (Market at Battery),75,8/29/2013 13:15,Clay at Battery,41,315,Subscriber,10009
+4765,228,8/29/2013 17:05,South Van Ness at Market,66,8/29/2013 17:08,Market at 10th,67,553,Subscriber,94103
+5001,236,8/29/2013 20:00,2nd at Folsom,62,8/29/2013 20:04,Market at Sansome,77,567,Customer,94608
+5002,236,8/29/2013 20:01,Golden Gate at Polk,59,8/29/2013 20:05,South Van Ness at Market,66,375,Subscriber,94122
+4560,237,8/29/2013 13:58,South Van Ness at Market,66,8/29/2013 14:02,San Francisco City Hall,58,438,Subscriber,94124
+4592,239,8/29/2013 14:30,Post at Kearney,47,8/29/2013 14:34,Market at Sansome,77,505,Subscriber,94109
+4673,239,8/29/2013 15:48,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 15:52,Townsend at 7th,65,568,Subscriber,94110
+4714,240,8/29/2013 16:21,MLK Library,11,8/29/2013 16:25,SJSU 4th at San Carlos,12,88,Subscriber,95112
+4748,240,8/29/2013 16:56,Harry Bridges Plaza (Ferry Building),50,8/29/2013 17:00,Beale at Market,56,626,Subscriber,94122
+4317,241,8/29/2013 12:07,San Francisco City Hall,58,8/29/2013 12:11,South Van Ness at Market,66,587,Subscriber,94597
+4559,242,8/29/2013 13:58,South Van Ness at Market,66,8/29/2013 14:02,San Francisco City Hall,58,554,Subscriber,94115
+4880,242,8/29/2013 18:10,Clay at Battery,41,8/29/2013 18:14,Washington at Kearney,46,530,Subscriber,94115
+4668,243,8/29/2013 15:39,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 15:43,Townsend at 7th,65,489,Subscriber,94107
+4667,244,8/29/2013 15:39,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 15:43,Townsend at 7th,65,431,Subscriber,94109
+4443,245,8/29/2013 12:56,Market at Sansome,77,8/29/2013 13:00,Steuart at Market,74,436,Customer,94960
+5105,245,8/29/2013 23:12,Townsend at 7th,65,8/29/2013 23:16,San Francisco Caltrain (Townsend at 4th),70,348,Customer,37206
+4341,252,8/29/2013 12:13,San Francisco City Hall,58,8/29/2013 12:17,South Van Ness at Market,66,547,Subscriber,94115
+4423,254,8/29/2013 12:50,Harry Bridges Plaza (Ferry Building),50,8/29/2013 12:54,Clay at Battery,41,544,Subscriber,94070
+4911,259,8/29/2013 18:38,San Francisco City Hall,58,8/29/2013 18:42,South Van Ness at Market,66,411,Subscriber,94131
+4504,262,8/29/2013 13:29,Civic Center BART (7th at Market),72,8/29/2013 13:34,Market at 10th,67,398,Subscriber,94114
+4584,262,8/29/2013 14:17,South Van Ness at Market,66,8/29/2013 14:21,South Van Ness at Market,66,587,Subscriber,94612
+4599,265,8/29/2013 14:31,Embarcadero at Sansome,60,8/29/2013 14:35,Davis at Jackson,42,425,Customer,2360
+4801,265,8/29/2013 17:24,San Francisco City Hall,58,8/29/2013 17:28,San Francisco City Hall,58,554,Subscriber,94109
+4870,266,8/29/2013 18:06,Market at 4th,76,8/29/2013 18:10,Beale at Market,56,626,Customer,43214
+4743,267,8/29/2013 16:51,Evelyn Park and Ride,30,8/29/2013 16:55,Mountain View Caltrain Station,28,54,Customer,94107
+4799,267,8/29/2013 17:19,Davis at Jackson,42,8/29/2013 17:24,Steuart at Market,74,399,Subscriber,94105
+5006,269,8/29/2013 20:09,Market at 4th,76,8/29/2013 20:14,Powell at Post (Union Square),71,528,Subscriber,94109
+4686,273,8/29/2013 15:59,Market at Sansome,77,8/29/2013 16:03,Temporary Transbay Terminal (Howard at Beale),55,624,Customer,
+4906,277,8/29/2013 18:28,University and Emerson,35,8/29/2013 18:33,Cowper at University,37,93,Customer,94303
+4177,278,8/29/2013 11:03,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 11:08,2nd at South Park,64,371,Subscriber,94117
+4436,284,8/29/2013 12:55,Embarcadero at Sansome,60,8/29/2013 13:00,Embarcadero at Vallejo,48,488,Subscriber,94109
+5057,284,8/29/2013 21:10,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 21:15,Market at Sansome,77,413,Subscriber,94117
+4084,287,8/29/2013 9:41,Mountain View City Hall,27,8/29/2013 9:46,Mountain View City Hall,27,138,Customer,97214
+4595,288,8/29/2013 14:31,Embarcadero at Sansome,60,8/29/2013 14:36,Davis at Jackson,42,356,Customer,1719
+4377,289,8/29/2013 12:27,Market at Sansome,77,8/29/2013 12:32,Temporary Transbay Terminal (Howard at Beale),55,471,Subscriber,94965
+4600,291,8/29/2013 14:33,San Pedro Square,6,8/29/2013 14:38,San Jose City Hall,10,35,Subscriber,95138
+4959,292,8/29/2013 19:18,Townsend at 7th,65,8/29/2013 19:23,San Francisco Caltrain 2 (330 Townsend),69,361,Customer,94109
+4828,293,8/29/2013 17:41,Palo Alto Caltrain Station,34,8/29/2013 17:46,University and Emerson,35,160,Subscriber,94107
+4450,298,8/29/2013 13:01,Embarcadero at Vallejo,48,8/29/2013 13:06,Davis at Jackson,42,598,Subscriber,94109
+4558,298,8/29/2013 13:57,Embarcadero at Bryant,54,8/29/2013 14:02,Harry Bridges Plaza (Ferry Building),50,275,Subscriber,94109
+4657,298,8/29/2013 15:30,5th at Howard,57,8/29/2013 15:35,5th at Howard,57,631,Subscriber,94123
+4796,305,8/29/2013 17:22,Civic Center BART (7th at Market),72,8/29/2013 17:27,Market at 4th,76,332,Subscriber,94110
+4331,307,8/29/2013 12:12,University and Emerson,35,8/29/2013 12:17,Cowper at University,37,144,Subscriber,94025
+4280,309,8/29/2013 11:53,San Francisco City Hall,58,8/29/2013 11:58,South Van Ness at Market,66,636,Subscriber,94117
+4290,309,8/29/2013 11:58,Powell Street BART,39,8/29/2013 12:03,Market at 10th,67,496,Customer,94107
+4876,309,8/29/2013 18:09,2nd at Townsend,61,8/29/2013 18:14,San Francisco Caltrain 2 (330 Townsend),69,565,Customer,95126
+4766,315,8/29/2013 17:05,San Mateo County Center,23,8/29/2013 17:10,San Mateo County Center,23,227,Subscriber,94402
+4871,316,8/29/2013 18:06,5th at Howard,57,8/29/2013 18:11,San Francisco Caltrain (Townsend at 4th),70,348,Customer,94107
+5078,318,8/29/2013 21:53,Civic Center BART (7th at Market),72,8/29/2013 21:59,Powell Street BART,39,611,Subscriber,94115
+4744,319,8/29/2013 16:52,5th at Howard,57,8/29/2013 16:57,San Francisco Caltrain (Townsend at 4th),70,379,Customer,95032
+4376,320,8/29/2013 12:27,Clay at Battery,41,8/29/2013 12:32,Harry Bridges Plaza (Ferry Building),50,534,Subscriber,94115
+4392,323,8/29/2013 12:34,Harry Bridges Plaza (Ferry Building),50,8/29/2013 12:39,Embarcadero at Vallejo,48,428,Subscriber,94123
+4602,323,8/29/2013 14:34,Commercial at Montgomery,45,8/29/2013 14:39,Davis at Jackson,42,326,Customer,94111
+5100,323,8/29/2013 22:50,Steuart at Market,74,8/29/2013 22:56,Spear at Folsom,49,317,Subscriber,94105
+4448,324,8/29/2013 13:01,Embarcadero at Vallejo,48,8/29/2013 13:06,Davis at Jackson,42,621,Subscriber,94121
+4722,327,8/29/2013 16:32,San Salvador at 1st,8,8/29/2013 16:37,San Jose Civic Center,3,81,Subscriber,95112
+4850,327,8/29/2013 17:53,Cowper at University,37,8/29/2013 17:59,University and Emerson,35,95,Subscriber,94107
+4615,332,8/29/2013 14:55,Market at 4th,76,8/29/2013 15:01,Howard at 2nd,63,606,Subscriber,94109
+4582,335,8/29/2013 14:14,2nd at Folsom,62,8/29/2013 14:20,2nd at Folsom,62,342,Subscriber,94123
+4640,335,8/29/2013 15:19,2nd at South Park,64,8/29/2013 15:24,San Francisco Caltrain (Townsend at 4th),70,438,Subscriber,94110
+4805,336,8/29/2013 17:26,Santa Clara at Almaden,4,8/29/2013 17:32,San Jose City Hall,10,26,Subscriber,95066
+4715,337,8/29/2013 16:23,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 16:29,Townsend at 7th,65,489,Customer,94109
+4941,337,8/29/2013 19:05,Embarcadero at Vallejo,48,8/29/2013 19:11,Harry Bridges Plaza (Ferry Building),50,327,Subscriber,94103
+4454,340,8/29/2013 13:05,Market at Sansome,77,8/29/2013 13:10,Washington at Kearney,46,590,Subscriber,94107
+4647,340,8/29/2013 15:26,Golden Gate at Polk,59,8/29/2013 15:32,Powell Street BART,39,432,Subscriber,94102
+4750,342,8/29/2013 16:57,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 17:03,Powell Street BART,39,549,Subscriber,94109
+4393,343,8/29/2013 12:34,Commercial at Montgomery,45,8/29/2013 12:40,Market at Sansome,77,319,Subscriber,94103
+4822,343,8/29/2013 17:37,San Jose City Hall,10,8/29/2013 17:43,San Pedro Square,6,196,Subscriber,95138
+4300,346,8/29/2013 12:03,Post at Kearney,47,8/29/2013 12:09,Harry Bridges Plaza (Ferry Building),50,603,Customer,94105
+4968,346,8/29/2013 19:35,Embarcadero at Bryant,54,8/29/2013 19:41,Spear at Folsom,49,512,Subscriber,94105
+4890,347,8/29/2013 18:13,Davis at Jackson,42,8/29/2013 18:19,Beale at Market,56,326,Subscriber,94123
+5075,348,8/29/2013 21:47,South Van Ness at Market,66,8/29/2013 21:52,Civic Center BART (7th at Market),72,598,Subscriber,94115
+4570,351,8/29/2013 14:06,Harry Bridges Plaza (Ferry Building),50,8/29/2013 14:12,Washington at Kearney,46,275,Subscriber,94109
+4278,353,8/29/2013 11:52,Harry Bridges Plaza (Ferry Building),50,8/29/2013 11:58,Commercial at Montgomery,45,596,Subscriber,94123
+4399,355,8/29/2013 12:39,Redwood City Caltrain Station,22,8/29/2013 12:45,Redwood City Medical Center,26,74,Subscriber,94041
+4660,355,8/29/2013 15:32,Powell at Post (Union Square),71,8/29/2013 15:38,Post at Kearney,47,408,Customer,94102
+4745,360,8/29/2013 16:52,Embarcadero at Folsom,51,8/29/2013 16:58,Temporary Transbay Terminal (Howard at Beale),55,271,Subscriber,94133
+4955,360,8/29/2013 19:15,Golden Gate at Polk,59,8/29/2013 19:21,Market at 10th,67,498,Subscriber,94608
+4785,361,8/29/2013 17:13,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 17:19,San Francisco Caltrain (Townsend at 4th),70,562,Subscriber,94401
+4730,362,8/29/2013 16:37,Townsend at 7th,65,8/29/2013 16:43,San Francisco Caltrain (Townsend at 4th),70,615,Subscriber,94112
+4786,362,8/29/2013 17:14,Market at 10th,67,8/29/2013 17:20,Golden Gate at Polk,59,351,Subscriber,94597
+4447,363,8/29/2013 13:00,Steuart at Market,74,8/29/2013 13:06,Spear at Folsom,49,341,Subscriber,94112
+5032,363,8/29/2013 20:33,San Jose Civic Center,3,8/29/2013 20:39,San Pedro Square,6,683,Customer,95123
+4312,369,8/29/2013 12:06,Commercial at Montgomery,45,8/29/2013 12:12,Mechanics Plaza (Market at Battery),75,378,Subscriber,94117
+4695,369,8/29/2013 16:05,Townsend at 7th,65,8/29/2013 16:11,San Francisco Caltrain (Townsend at 4th),70,431,Customer,95118
+4700,369,8/29/2013 16:12,Davis at Jackson,42,8/29/2013 16:18,Grant Avenue at Columbus Avenue,73,510,Customer,2360
+4875,370,8/29/2013 18:08,Embarcadero at Sansome,60,8/29/2013 18:14,Davis at Jackson,42,421,Subscriber,94110
+4659,371,8/29/2013 15:32,Powell at Post (Union Square),71,8/29/2013 15:38,Post at Kearney,47,538,Customer,94102
+4998,374,8/29/2013 19:57,Harry Bridges Plaza (Ferry Building),50,8/29/2013 20:04,Spear at Folsom,49,276,Subscriber,94105
+4496,375,8/29/2013 13:19,Townsend at 7th,65,8/29/2013 13:25,San Francisco Caltrain (Townsend at 4th),70,413,Subscriber,94107
+4716,375,8/29/2013 16:24,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 16:30,Townsend at 7th,65,382,Customer,95118
+4527,376,8/29/2013 13:39,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 13:45,Powell Street BART,39,522,Subscriber,94610
+4612,376,8/29/2013 14:46,St James Park,13,8/29/2013 14:53,Japantown,9,188,Subscriber,95112
+4204,378,8/29/2013 11:06,San Jose City Hall,10,8/29/2013 11:13,San Jose City Hall,10,28,Subscriber,95136
+4731,378,8/29/2013 16:36,Beale at Market,56,8/29/2013 16:43,Commercial at Montgomery,45,324,Customer,94118
+4883,378,8/29/2013 18:12,Market at 4th,76,8/29/2013 18:18,Howard at 2nd,63,332,Subscriber,94114
+4517,379,8/29/2013 13:34,San Salvador at 1st,8,8/29/2013 13:41,San Jose City Hall,10,661,Subscriber,95112
+4429,380,8/29/2013 12:53,Embarcadero at Sansome,60,8/29/2013 13:00,Embarcadero at Vallejo,48,491,Subscriber,94121
+4699,380,8/29/2013 16:12,Davis at Jackson,42,8/29/2013 16:18,Grant Avenue at Columbus Avenue,73,443,Customer,1719
+4434,384,8/29/2013 12:55,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 13:01,San Francisco Caltrain 2 (330 Townsend),69,555,Subscriber,94117
+4408,385,8/29/2013 12:41,5th at Howard,57,8/29/2013 12:48,Powell at Post (Union Square),71,538,Customer,37206
+4961,387,8/29/2013 19:21,Temporary Transbay Terminal (Howard at Beale),55,8/29/2013 19:28,5th at Howard,57,471,Subscriber,94103
+5099,387,8/29/2013 22:35,San Jose Civic Center,3,8/29/2013 22:41,San Jose Diridon Caltrain Station,2,675,Subscriber,95126
+4725,388,8/29/2013 16:34,Embarcadero at Bryant,54,8/29/2013 16:41,Steuart at Market,74,277,Subscriber,94109
+4347,389,8/29/2013 12:15,San Jose City Hall,10,8/29/2013 12:21,San Pedro Square,6,146,Subscriber,95112
+5095,390,8/29/2013 22:15,Market at Sansome,77,8/29/2013 22:21,Steuart at Market,74,501,Subscriber,94115
+5102,392,8/29/2013 22:53,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 23:00,Howard at 2nd,63,348,Customer,37206
+4414,393,8/29/2013 12:44,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 12:50,San Francisco Caltrain 2 (330 Townsend),69,259,Customer,91127
+5050,396,8/29/2013 21:01,Powell Street BART,39,8/29/2013 21:07,Civic Center BART (7th at Market),72,402,Subscriber,94103
+4334,398,8/29/2013 12:12,Market at Sansome,77,8/29/2013 12:19,Harry Bridges Plaza (Ferry Building),50,428,Customer,94709
+4385,398,8/29/2013 12:30,Civic Center BART (7th at Market),72,8/29/2013 12:37,Golden Gate at Polk,59,397,Subscriber,94109
+4981,399,8/29/2013 19:41,South Van Ness at Market,66,8/29/2013 19:47,Market at 10th,67,632,Subscriber,94110
+5062,402,8/29/2013 21:27,Post at Kearney,47,8/29/2013 21:34,Howard at 2nd,63,616,Subscriber,94105
+4970,404,8/29/2013 19:36,5th at Howard,57,8/29/2013 19:43,Powell at Post (Union Square),71,320,Subscriber,94109
+4458,405,8/29/2013 13:05,Powell at Post (Union Square),71,8/29/2013 13:12,Powell at Post (Union Square),71,458,Subscriber,94102
+4879,405,8/29/2013 18:10,Post at Kearney,47,8/29/2013 18:17,Harry Bridges Plaza (Ferry Building),50,394,Subscriber,94102
+4999,405,8/29/2013 19:58,Harry Bridges Plaza (Ferry Building),50,8/29/2013 20:04,Spear at Folsom,49,282,Subscriber,94105
+4751,406,8/29/2013 16:57,San Francisco City Hall,58,8/29/2013 17:04,Powell Street BART,39,462,Subscriber,94704
+4996,410,8/29/2013 19:57,Market at Sansome,77,8/29/2013 20:04,Commercial at Montgomery,45,441,Customer,8540
+4616,412,8/29/2013 14:56,St James Park,13,8/29/2013 15:02,Japantown,9,101,Customer,95020
+4741,412,8/29/2013 16:45,Adobe on Almaden,5,8/29/2013 16:52,San Jose City Hall,10,679,Subscriber,95112
+4910,412,8/29/2013 18:37,Cowper at University,37,8/29/2013 18:43,Palo Alto Caltrain Station,34,20,Customer,94303
+4655,413,8/29/2013 15:29,Grant Avenue at Columbus Avenue,73,8/29/2013 15:36,Washington at Kearney,46,474,Customer,
+4542,416,8/29/2013 13:49,Commercial at Montgomery,45,8/29/2013 13:56,Davis at Jackson,42,399,Customer,94111
+4348,418,8/29/2013 12:14,Temporary Transbay Terminal (Howard at Beale),55,8/29/2013 12:21,Market at Sansome,77,628,Subscriber,94965
+4435,418,8/29/2013 12:55,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 13:02,Washington at Kearney,46,548,Customer,2142
+4465,419,8/29/2013 13:11,2nd at South Park,64,8/29/2013 13:18,Post at Kearney,47,498,Subscriber,94117
+4810,419,8/29/2013 17:30,Market at 4th,76,8/29/2013 17:37,Civic Center BART (7th at Market),72,546,Subscriber,94122
+4641,420,8/29/2013 15:19,Powell Street BART,39,8/29/2013 15:26,San Francisco Caltrain (Townsend at 4th),70,522,Subscriber,94102
+4571,421,8/29/2013 14:07,Davis at Jackson,42,8/29/2013 14:14,Commercial at Montgomery,45,621,Customer,94111
+5077,422,8/29/2013 21:47,Market at Sansome,77,8/29/2013 21:54,Davis at Jackson,42,619,Customer,1719
+4309,423,8/29/2013 12:04,Steuart at Market,74,8/29/2013 12:11,Embarcadero at Folsom,51,340,Subscriber,94127
+4953,423,8/29/2013 19:14,Clay at Battery,41,8/29/2013 19:21,Market at 4th,76,606,Subscriber,94110
+5067,423,8/29/2013 21:38,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 21:45,San Francisco Caltrain 2 (330 Townsend),69,535,Subscriber,94133
+4830,424,8/29/2013 17:42,Spear at Folsom,49,8/29/2013 17:49,Yerba Buena Center of the Arts (3rd @ Howard),68,334,Customer,
+4464,425,8/29/2013 13:09,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 13:16,Townsend at 7th,65,318,Subscriber,94107
+4529,425,8/29/2013 13:40,Howard at 2nd,63,8/29/2013 13:47,Spear at Folsom,49,361,Subscriber,94110
+4296,430,8/29/2013 12:00,Post at Kearney,47,8/29/2013 12:08,2nd at South Park,64,593,Subscriber,94117
+4784,430,8/29/2013 17:13,Market at 10th,67,8/29/2013 17:20,Golden Gate at Polk,59,506,Subscriber,94703
+5004,430,8/29/2013 20:05,Davis at Jackson,42,8/29/2013 20:12,Market at Sansome,77,377,Subscriber,94110
+4455,431,8/29/2013 13:05,South Van Ness at Market,66,8/29/2013 13:12,Powell Street BART,39,626,Subscriber,94122
+5061,433,8/29/2013 21:23,Commercial at Montgomery,45,8/29/2013 21:30,Market at 4th,76,400,Subscriber,94131
+4689,436,8/29/2013 16:01,Embarcadero at Sansome,60,8/29/2013 16:08,Harry Bridges Plaza (Ferry Building),50,584,Customer,94965
+4904,436,8/29/2013 18:26,Beale at Market,56,8/29/2013 18:34,Embarcadero at Bryant,54,512,Subscriber,94123
+5060,436,8/29/2013 21:22,Commercial at Montgomery,45,8/29/2013 21:30,Market at 4th,76,380,Subscriber,94131
+4783,438,8/29/2013 17:13,Market at 10th,67,8/29/2013 17:20,Golden Gate at Polk,59,617,Subscriber,94115
+4679,440,8/29/2013 15:54,Golden Gate at Polk,59,8/29/2013 16:02,Civic Center BART (7th at Market),72,397,Subscriber,94110
+5013,440,8/29/2013 20:13,Golden Gate at Polk,59,8/29/2013 20:20,South Van Ness at Market,66,617,Customer,95816
+5073,440,8/29/2013 21:44,Steuart at Market,74,8/29/2013 21:52,Embarcadero at Bryant,54,516,Subscriber,94105
+4445,441,8/29/2013 12:58,Harry Bridges Plaza (Ferry Building),50,8/29/2013 13:06,Post at Kearney,47,625,Customer,94105
+4343,445,8/29/2013 12:14,Harry Bridges Plaza (Ferry Building),50,8/29/2013 12:21,Howard at 2nd,63,603,Subscriber,94403
+5015,449,8/29/2013 20:13,Golden Gate at Polk,59,8/29/2013 20:21,South Van Ness at Market,66,322,Subscriber,94115
+4849,450,8/29/2013 17:53,Market at 4th,76,8/29/2013 18:01,San Francisco Caltrain (Townsend at 4th),70,592,Subscriber,94061
+4901,450,8/29/2013 18:26,2nd at Townsend,61,8/29/2013 18:33,Yerba Buena Center of the Arts (3rd @ Howard),68,621,Customer,94608
+4958,454,8/29/2013 19:18,San Jose Diridon Caltrain Station,2,8/29/2013 19:25,Paseo de San Antonio,7,91,Subscriber,95126
+4967,454,8/29/2013 19:35,Paseo de San Antonio,7,8/29/2013 19:42,San Jose Diridon Caltrain Station,2,91,Subscriber,95126
+4199,455,8/29/2013 11:05,Grant Avenue at Columbus Avenue,73,8/29/2013 11:13,Clay at Battery,41,409,Customer,95070
+4905,459,8/29/2013 18:28,Spear at Folsom,49,8/29/2013 18:35,Mechanics Plaza (Market at Battery),75,341,Subscriber,94110
+4298,460,8/29/2013 12:02,Cowper at University,37,8/29/2013 12:10,University and Emerson,35,9,Subscriber,94025
+4486,460,8/29/2013 13:16,Market at Sansome,77,8/29/2013 13:24,Market at 4th,76,606,Customer,94158
+4396,462,8/29/2013 12:36,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 12:43,2nd at South Park,64,569,Customer,94133
+4536,462,8/29/2013 13:44,Powell Street BART,39,8/29/2013 13:51,Golden Gate at Polk,59,316,Customer,94110
+4761,462,8/29/2013 17:01,Howard at 2nd,63,8/29/2013 17:09,Powell Street BART,39,606,Subscriber,94703
+4125,464,8/29/2013 10:14,Mechanics Plaza (Market at Battery),75,8/29/2013 10:22,Powell at Post (Union Square),71,528,Subscriber,94110
+4314,464,8/29/2013 12:07,Clay at Battery,41,8/29/2013 12:14,Clay at Battery,41,409,Customer,94105
+4837,466,8/29/2013 17:46,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 17:54,Townsend at 7th,65,361,Customer,94107
+4301,471,8/29/2013 12:03,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 12:11,Yerba Buena Center of the Arts (3rd @ Howard),68,522,Subscriber,94117
+4860,472,8/29/2013 17:59,San Francisco City Hall,58,8/29/2013 18:07,Golden Gate at Polk,59,367,Subscriber,94703
+4442,474,8/29/2013 12:56,Washington at Kearney,46,8/29/2013 13:04,Market at Sansome,77,607,Subscriber,94107
+4936,474,8/29/2013 18:58,Embarcadero at Folsom,51,8/29/2013 19:06,Yerba Buena Center of the Arts (3rd @ Howard),68,318,Subscriber,94105
+4483,475,8/29/2013 13:16,Market at Sansome,77,8/29/2013 13:24,Market at 4th,76,333,Customer,94158
+4666,475,8/29/2013 15:36,Embarcadero at Sansome,60,8/29/2013 15:44,Harry Bridges Plaza (Ferry Building),50,372,Customer,2142
+4980,475,8/29/2013 19:40,Embarcadero at Bryant,54,8/29/2013 19:48,Spear at Folsom,49,283,Subscriber,94105
+4787,479,8/29/2013 17:12,Beale at Market,56,8/29/2013 17:20,Market at 4th,76,546,Subscriber,94122
+5066,481,8/29/2013 21:35,Howard at 2nd,63,8/29/2013 21:43,Steuart at Market,74,603,Subscriber,94105
+4859,482,8/29/2013 17:59,San Francisco City Hall,58,8/29/2013 18:07,Golden Gate at Polk,59,527,Subscriber,94122
+4409,485,8/29/2013 12:42,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 12:50,San Francisco Caltrain 2 (330 Townsend),69,327,Subscriber,94110
+4605,486,8/29/2013 14:36,Market at Sansome,77,8/29/2013 14:44,Powell at Post (Union Square),71,628,Subscriber,94109
+4942,486,8/29/2013 19:05,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 19:13,Townsend at 7th,65,565,Customer,94107
+4809,489,8/29/2013 17:29,Powell Street BART,39,8/29/2013 17:38,Market at 10th,67,632,Subscriber,94103
+4678,491,8/29/2013 15:54,Embarcadero at Sansome,60,8/29/2013 16:02,Grant Avenue at Columbus Avenue,73,570,Customer,8053
+5076,491,8/29/2013 21:47,Market at Sansome,77,8/29/2013 21:55,Davis at Jackson,42,413,Customer,2360
+4779,492,8/29/2013 17:11,Powell Street BART,39,8/29/2013 17:19,Clay at Battery,41,606,Subscriber,94109
+4518,497,8/29/2013 13:35,Clay at Battery,41,8/29/2013 13:43,2nd at Folsom,62,409,Customer,94105
+4123,500,8/29/2013 10:14,Grant Avenue at Columbus Avenue,73,8/29/2013 10:22,Clay at Battery,41,503,Subscriber,94115
+4321,505,8/29/2013 12:10,Market at Sansome,77,8/29/2013 12:19,Harry Bridges Plaza (Ferry Building),50,625,Subscriber,94110
+4304,508,8/29/2013 12:04,San Francisco City Hall,58,8/29/2013 12:12,Civic Center BART (7th at Market),72,374,Subscriber,94109
+4710,508,8/29/2013 16:17,Harry Bridges Plaza (Ferry Building),50,8/29/2013 16:26,Embarcadero at Vallejo,48,386,Subscriber,94103
+4420,512,8/29/2013 12:46,Townsend at 7th,65,8/29/2013 12:54,2nd at South Park,64,498,Subscriber,94110
+4627,515,8/29/2013 15:02,Davis at Jackson,42,8/29/2013 15:10,Davis at Jackson,42,425,Customer,94111
+4587,519,8/29/2013 14:21,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 14:30,Powell Street BART,39,555,Subscriber,94102
+4320,520,8/29/2013 12:10,Market at Sansome,77,8/29/2013 12:19,Harry Bridges Plaza (Ferry Building),50,616,Subscriber,94109
+4711,522,8/29/2013 16:17,Harry Bridges Plaza (Ferry Building),50,8/29/2013 16:26,Embarcadero at Vallejo,48,524,Subscriber,94110
+4817,523,8/29/2013 17:33,San Jose Diridon Caltrain Station,2,8/29/2013 17:42,San Jose City Hall,10,86,Customer,95126
+4969,527,8/29/2013 19:36,Grant Avenue at Columbus Avenue,73,8/29/2013 19:44,Temporary Transbay Terminal (Howard at Beale),55,353,Customer,
+4632,530,8/29/2013 15:08,Market at 4th,76,8/29/2013 15:17,Civic Center BART (7th at Market),72,615,Subscriber,94114
+5046,531,8/29/2013 20:57,Embarcadero at Folsom,51,8/29/2013 21:05,San Francisco Caltrain 2 (330 Townsend),69,268,Subscriber,94133
+4440,534,8/29/2013 12:55,Civic Center BART (7th at Market),72,8/29/2013 13:04,Market at 4th,76,430,Subscriber,94127
+4933,535,8/29/2013 18:56,Embarcadero at Bryant,54,8/29/2013 19:05,Harry Bridges Plaza (Ferry Building),50,282,Subscriber,94105
+4310,537,8/29/2013 12:05,Japantown,9,8/29/2013 12:14,Japantown,9,638,Subscriber,95112
+5016,537,8/29/2013 20:14,Embarcadero at Sansome,60,8/29/2013 20:23,Clay at Battery,41,538,Subscriber,94105
+5014,538,8/29/2013 20:13,Golden Gate at Polk,59,8/29/2013 20:22,Market at 10th,67,610,Subscriber,94597
+4369,540,8/29/2013 12:25,Davis at Jackson,42,8/29/2013 12:34,Market at 4th,76,617,Customer,1719
+4439,540,8/29/2013 12:55,Civic Center BART (7th at Market),72,8/29/2013 13:04,Market at 4th,76,390,Subscriber,94127
+5029,541,8/29/2013 20:29,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 20:38,San Francisco Caltrain (Townsend at 4th),70,318,Subscriber,94404
+4833,543,8/29/2013 17:45,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 17:54,Market at Sansome,77,619,Subscriber,94115
+4934,545,8/29/2013 18:56,Embarcadero at Bryant,54,8/29/2013 19:05,Harry Bridges Plaza (Ferry Building),50,276,Subscriber,94105
+4903,546,8/29/2013 18:26,Post at Kearney,47,8/29/2013 18:35,Grant Avenue at Columbus Avenue,73,608,Customer,94103
+4762,551,8/29/2013 17:03,Powell Street BART,39,8/29/2013 17:12,Harry Bridges Plaza (Ferry Building),50,435,Customer,8884
+4691,553,8/29/2013 16:01,Townsend at 7th,65,8/29/2013 16:11,San Francisco Caltrain (Townsend at 4th),70,489,Customer,94109
+5024,555,8/29/2013 20:25,Temporary Transbay Terminal (Howard at Beale),55,8/29/2013 20:35,Market at 4th,76,582,Customer,94109
+4419,556,8/29/2013 12:45,Adobe on Almaden,5,8/29/2013 12:55,San Jose Civic Center,3,671,Subscriber,94536
+4776,560,8/29/2013 17:09,Market at 10th,67,8/29/2013 17:18,Powell Street BART,39,410,Subscriber,94103
+4902,560,8/29/2013 18:26,Post at Kearney,47,8/29/2013 18:35,Grant Avenue at Columbus Avenue,73,625,Customer,94103
+5010,561,8/29/2013 20:12,Golden Gate at Polk,59,8/29/2013 20:21,South Van Ness at Market,66,351,Subscriber,94703
+4374,563,8/29/2013 12:23,Beale at Market,56,8/29/2013 12:32,Commercial at Montgomery,45,410,Subscriber,94117
+4561,563,8/29/2013 13:58,San Salvador at 1st,8,8/29/2013 14:07,San Salvador at 1st,8,46,Subscriber,95112
+4661,563,8/29/2013 15:33,Embarcadero at Sansome,60,8/29/2013 15:42,Steuart at Market,74,422,Customer,95819
+4788,563,8/29/2013 17:16,Spear at Folsom,49,8/29/2013 17:25,Embarcadero at Sansome,60,558,Subscriber,94102
+4829,566,8/29/2013 17:42,5th at Howard,57,8/29/2013 17:51,Embarcadero at Folsom,51,318,Customer,94501
+4478,567,8/29/2013 13:15,Commercial at Montgomery,45,8/29/2013 13:24,Powell Street BART,39,386,Subscriber,94102
+4865,570,8/29/2013 18:02,Post at Kearney,47,8/29/2013 18:12,Grant Avenue at Columbus Avenue,73,381,Subscriber,94114
+4405,571,8/29/2013 12:41,Market at Sansome,77,8/29/2013 12:50,Market at 10th,67,319,Subscriber,94103
+4282,572,8/29/2013 11:54,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 12:04,Townsend at 7th,65,538,Customer,37206
+4287,572,8/29/2013 11:56,Powell Street BART,39,8/29/2013 12:06,Commercial at Montgomery,45,435,Subscriber,94102
+4808,572,8/29/2013 17:27,South Van Ness at Market,66,8/29/2013 17:37,Golden Gate at Polk,59,375,Customer,94122
+5085,573,8/29/2013 22:06,San Jose Civic Center,3,8/29/2013 22:16,St James Park,13,639,Subscriber,95112
+4134,574,8/29/2013 10:19,Market at 4th,76,8/29/2013 10:29,2nd at South Park,64,426,Customer,94117
+4367,579,8/29/2013 12:24,San Francisco City Hall,58,8/29/2013 12:34,South Van Ness at Market,66,520,Subscriber,94122
+4524,579,8/29/2013 13:39,Howard at 2nd,63,8/29/2013 13:48,San Francisco Caltrain (Townsend at 4th),70,358,Subscriber,94117
+4834,579,8/29/2013 17:45,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 17:55,Embarcadero at Folsom,51,615,Customer,94111
+4990,579,8/29/2013 19:48,Civic Center BART (7th at Market),72,8/29/2013 19:58,Townsend at 7th,65,319,Subscriber,94107
+4928,582,8/29/2013 18:55,Civic Center BART (7th at Market),72,8/29/2013 19:05,Townsend at 7th,65,345,Subscriber,94612
+4777,585,8/29/2013 17:09,Market at 10th,67,8/29/2013 17:18,Powell Street BART,39,553,Subscriber,94103
+4836,585,8/29/2013 17:46,Market at Sansome,77,8/29/2013 17:55,Davis at Jackson,42,529,Customer,1719
+4356,587,8/29/2013 12:18,Embarcadero at Vallejo,48,8/29/2013 12:28,Spear at Folsom,49,542,Subscriber,94105
+5086,587,8/29/2013 22:06,San Jose Civic Center,3,8/29/2013 22:16,St James Park,13,655,Subscriber,95112
+4929,590,8/29/2013 18:55,Civic Center BART (7th at Market),72,8/29/2013 19:05,Townsend at 7th,65,347,Subscriber,94107
+4581,591,8/29/2013 14:14,Commercial at Montgomery,45,8/29/2013 14:24,Harry Bridges Plaza (Ferry Building),50,566,Subscriber,94123
+4835,598,8/29/2013 17:45,Market at Sansome,77,8/29/2013 17:55,Davis at Jackson,42,505,Customer,2360
+4531,601,8/29/2013 13:41,Powell Street BART,39,8/29/2013 13:51,Golden Gate at Polk,59,432,Subscriber,94102
+4912,601,8/29/2013 18:39,Clay at Battery,41,8/29/2013 18:49,Powell Street BART,39,560,Subscriber,94103
+4706,606,8/29/2013 16:16,Harry Bridges Plaza (Ferry Building),50,8/29/2013 16:26,Embarcadero at Vallejo,48,370,Subscriber,94117
+4366,607,8/29/2013 12:24,San Francisco City Hall,58,8/29/2013 12:34,South Van Ness at Market,66,525,Subscriber,94703
+4398,607,8/29/2013 12:37,South Van Ness at Market,66,8/29/2013 12:47,Market at 4th,76,377,Subscriber,94117
+4610,607,8/29/2013 14:44,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 14:54,Mechanics Plaza (Market at Battery),75,550,Customer,94025
+5017,607,8/29/2013 20:13,Market at 10th,67,8/29/2013 20:24,Powell at Post (Union Square),71,632,Subscriber,94108
+4729,608,8/29/2013 16:36,South Van Ness at Market,66,8/29/2013 16:46,Powell Street BART,39,435,Subscriber,94107
+4379,610,8/29/2013 12:29,MLK Library,11,8/29/2013 12:39,MLK Library,11,669,Subscriber,95112
+4336,611,8/29/2013 12:12,Post at Kearney,47,8/29/2013 12:22,Harry Bridges Plaza (Ferry Building),50,602,Subscriber,94118
+4628,611,8/29/2013 15:03,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 15:13,Yerba Buena Center of the Arts (3rd @ Howard),68,562,Subscriber,94117
+4881,611,8/29/2013 18:11,Steuart at Market,74,8/29/2013 18:21,Powell Street BART,39,339,Subscriber,94115
+4728,612,8/29/2013 16:36,South Van Ness at Market,66,8/29/2013 16:46,Powell Street BART,39,431,Subscriber,94612
+4772,612,8/29/2013 17:07,Santa Clara at Almaden,4,8/29/2013 17:17,San Jose Diridon Caltrain Station,2,670,Subscriber,94158
+4864,614,8/29/2013 18:02,Post at Kearney,47,8/29/2013 18:13,Grant Avenue at Columbus Avenue,73,408,Customer,96001
+4918,615,8/29/2013 18:46,Embarcadero at Vallejo,48,8/29/2013 18:57,Spear at Folsom,49,259,Subscriber,94105
+4410,620,8/29/2013 12:42,Clay at Battery,41,8/29/2013 12:53,Mechanics Plaza (Market at Battery),75,601,Customer,94103
+4795,621,8/29/2013 17:22,Beale at Market,56,8/29/2013 17:32,Market at 4th,76,626,Customer,
+5008,623,8/29/2013 20:12,San Pedro Square,6,8/29/2013 20:22,Japantown,9,196,Subscriber,95110
+4537,624,8/29/2013 13:45,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 13:55,Market at 4th,76,524,Subscriber,94061
+4626,624,8/29/2013 15:02,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 15:13,Yerba Buena Center of the Arts (3rd @ Howard),68,413,Subscriber,94401
+4782,626,8/29/2013 17:12,Townsend at 7th,65,8/29/2013 17:23,San Francisco Caltrain 2 (330 Townsend),69,444,Subscriber,94107
+4428,627,8/29/2013 12:53,Harry Bridges Plaza (Ferry Building),50,8/29/2013 13:04,Post at Kearney,47,616,Subscriber,94118
+4256,629,8/29/2013 11:32,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 11:43,Embarcadero at Bryant,54,376,Subscriber,94105
+4868,633,8/29/2013 18:04,Market at 10th,67,8/29/2013 18:15,Market at Sansome,77,633,Subscriber,94703
+4360,637,8/29/2013 12:21,South Van Ness at Market,66,8/29/2013 12:32,Market at 4th,76,636,Subscriber,94117
+4724,637,8/29/2013 16:34,South Van Ness at Market,66,8/29/2013 16:44,5th at Howard,57,320,Subscriber,94107
+4499,638,8/29/2013 13:25,Embarcadero at Vallejo,48,8/29/2013 13:36,Market at 4th,76,529,Subscriber,94114
+4889,638,8/29/2013 18:18,Howard at 2nd,63,8/29/2013 18:29,2nd at South Park,64,637,Subscriber,94114
+4684,640,8/29/2013 15:58,Market at 10th,67,8/29/2013 16:08,San Francisco Caltrain 2 (330 Townsend),69,398,Subscriber,94115
+4814,641,8/29/2013 17:32,Powell at Post (Union Square),71,8/29/2013 17:43,Harry Bridges Plaza (Ferry Building),50,391,Subscriber,94117
+4848,642,8/29/2013 17:53,Powell Street BART,39,8/29/2013 18:04,San Francisco Caltrain (Townsend at 4th),70,416,Customer,90019
+4937,642,8/29/2013 18:59,Powell at Post (Union Square),71,8/29/2013 19:10,Yerba Buena Center of the Arts (3rd @ Howard),68,487,Customer,94108
+5087,643,8/29/2013 22:07,San Jose Civic Center,3,8/29/2013 22:18,San Jose Diridon Caltrain Station,2,664,Customer,95126
+4885,644,8/29/2013 18:14,South Van Ness at Market,66,8/29/2013 18:25,San Francisco Caltrain 2 (330 Townsend),69,514,Subscriber,94103
+5005,645,8/29/2013 20:06,Market at 4th,76,8/29/2013 20:17,South Van Ness at Market,66,584,Subscriber,94110
+4462,646,8/29/2013 13:07,Davis at Jackson,42,8/29/2013 13:18,Mechanics Plaza (Market at Battery),75,543,Subscriber,94109
+4525,650,8/29/2013 13:39,Howard at 2nd,63,8/29/2013 13:50,San Francisco Caltrain (Townsend at 4th),70,359,Subscriber,94401
+4543,650,8/29/2013 13:50,Commercial at Montgomery,45,8/29/2013 14:00,Commercial at Montgomery,45,435,Subscriber,94115
+4723,654,8/29/2013 16:33,South Van Ness at Market,66,8/29/2013 16:44,5th at Howard,57,379,Subscriber,94109
+4285,657,8/29/2013 11:56,Harry Bridges Plaza (Ferry Building),50,8/29/2013 12:07,Embarcadero at Vallejo,48,338,Subscriber,94608
+4413,659,8/29/2013 12:43,Post at Kearney,47,8/29/2013 12:54,Davis at Jackson,42,476,Customer,94115
+5104,661,8/29/2013 23:00,Howard at 2nd,63,8/29/2013 23:11,Townsend at 7th,65,348,Customer,37206
+4987,662,8/29/2013 19:45,Japantown,9,8/29/2013 19:56,San Pedro Square,6,686,Subscriber,95110
+4806,663,8/29/2013 17:27,Powell Street BART,39,8/29/2013 17:38,Market at 10th,67,431,Subscriber,94103
+5031,664,8/29/2013 20:32,Townsend at 7th,65,8/29/2013 20:44,Powell Street BART,39,568,Subscriber,94103
+5101,666,8/29/2013 22:51,Washington at Kearney,46,8/29/2013 23:02,Powell Street BART,39,474,Subscriber,94102
+4538,668,8/29/2013 13:45,Townsend at 7th,65,8/29/2013 13:56,2nd at Townsend,61,565,Customer,94121
+4674,671,8/29/2013 15:48,Powell at Post (Union Square),71,8/29/2013 15:59,Harry Bridges Plaza (Ferry Building),50,395,Customer,77520
+5106,672,8/29/2013 23:16,Embarcadero at Sansome,60,8/29/2013 23:27,Embarcadero at Folsom,51,558,Subscriber,94105
+4349,674,8/29/2013 12:15,Japantown,9,8/29/2013 12:26,SJSU 4th at San Carlos,12,46,Subscriber,95112
+4649,676,8/29/2013 15:26,Powell Street BART,39,8/29/2013 15:38,Harry Bridges Plaza (Ferry Building),50,626,Subscriber,94103
+4797,677,8/29/2013 17:22,Spear at Folsom,49,8/29/2013 17:33,San Francisco Caltrain (Townsend at 4th),70,361,Customer,94107
+4446,678,8/29/2013 13:00,Mechanics Plaza (Market at Battery),75,8/29/2013 13:11,Civic Center BART (7th at Market),72,540,Customer,94103
+4648,679,8/29/2013 15:26,Powell Street BART,39,8/29/2013 15:38,Harry Bridges Plaza (Ferry Building),50,490,Subscriber,94110
+4878,679,8/29/2013 18:09,Market at Sansome,77,8/29/2013 18:21,San Francisco City Hall,58,578,Customer,
+5059,679,8/29/2013 21:14,Grant Avenue at Columbus Avenue,73,8/29/2013 21:26,Powell at Post (Union Square),71,391,Customer,85224
+4651,684,8/29/2013 15:26,Powell Street BART,39,8/29/2013 15:38,Harry Bridges Plaza (Ferry Building),50,386,Subscriber,94122
+4676,684,8/29/2013 15:49,Townsend at 7th,65,8/29/2013 16:01,Civic Center BART (7th at Market),72,417,Subscriber,94109
+5020,684,8/29/2013 20:22,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 20:34,Civic Center BART (7th at Market),72,334,Subscriber,94114
+4887,685,8/29/2013 18:15,Harry Bridges Plaza (Ferry Building),50,8/29/2013 18:26,Powell Street BART,39,570,Customer,8884
+4406,687,8/29/2013 12:41,Steuart at Market,74,8/29/2013 12:53,Embarcadero at Sansome,60,561,Subscriber,94109
+4136,688,8/29/2013 10:20,Mountain View City Hall,27,8/29/2013 10:31,Mountain View City Hall,27,149,Customer,92545
+4552,688,8/29/2013 13:54,Market at 4th,76,8/29/2013 14:06,Embarcadero at Vallejo,48,562,Subscriber,94114
+4407,690,8/29/2013 12:41,Steuart at Market,74,8/29/2013 12:53,Embarcadero at Sansome,60,556,Subscriber,94121
+5009,690,8/29/2013 20:12,Golden Gate at Polk,59,8/29/2013 20:23,Market at 10th,67,367,Subscriber,94703
+5043,691,8/29/2013 20:46,Embarcadero at Bryant,54,8/29/2013 20:58,Harry Bridges Plaza (Ferry Building),50,286,Subscriber,94087
+4460,693,8/29/2013 13:08,2nd at Townsend,61,8/29/2013 13:20,Harry Bridges Plaza (Ferry Building),50,314,Customer,94608
+4556,693,8/29/2013 13:56,Clay at Battery,41,8/29/2013 14:08,Civic Center BART (7th at Market),72,496,Subscriber,94110
+5108,694,8/29/2013 23:57,Powell at Post (Union Square),71,8/30/2013 0:09,2nd at Townsend,61,477,Subscriber,94107
+4562,696,8/29/2013 14:00,Harry Bridges Plaza (Ferry Building),50,8/29/2013 14:12,2nd at Townsend,61,588,Customer,94608
+4624,697,8/29/2013 15:01,University and Emerson,35,8/29/2013 15:13,California Ave Caltrain Station,36,168,Customer,94306
+4644,698,8/29/2013 15:20,Market at 4th,76,8/29/2013 15:32,Harry Bridges Plaza (Ferry Building),50,617,Subscriber,94122
+4350,701,8/29/2013 12:16,Clay at Battery,41,8/29/2013 12:27,Post at Kearney,47,394,Customer,94612
+4403,702,8/29/2013 12:40,Civic Center BART (7th at Market),72,8/29/2013 12:52,Steuart at Market,74,576,Subscriber,94065
+4522,702,8/29/2013 13:37,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 13:49,South Van Ness at Market,66,554,Subscriber,94117
+4874,704,8/29/2013 18:07,San Jose Civic Center,3,8/29/2013 18:19,San Salvador at 1st,8,671,Subscriber,94116
+5058,704,8/29/2013 21:14,Grant Avenue at Columbus Avenue,73,8/29/2013 21:26,Powell at Post (Union Square),71,284,Customer,85224
+4642,710,8/29/2013 15:20,Market at 4th,76,8/29/2013 15:32,Harry Bridges Plaza (Ferry Building),50,333,Subscriber,94117
+4643,710,8/29/2013 15:20,Market at 4th,76,8/29/2013 15:32,Harry Bridges Plaza (Ferry Building),50,524,Subscriber,94061
+4466,711,8/29/2013 13:06,Mechanics Plaza (Market at Battery),75,8/29/2013 13:18,Temporary Transbay Terminal (Howard at Beale),55,537,Subscriber,94123
+4243,720,8/29/2013 11:26,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 11:38,San Francisco Caltrain (Townsend at 4th),70,538,Subscriber,94117
+4346,724,8/29/2013 12:14,Embarcadero at Folsom,51,8/29/2013 12:26,San Francisco Caltrain (Townsend at 4th),70,267,Subscriber,94127
+4872,726,8/29/2013 18:06,Harry Bridges Plaza (Ferry Building),50,8/29/2013 18:19,Grant Avenue at Columbus Avenue,73,391,Customer,94133
+5054,727,8/29/2013 21:05,Market at 4th,76,8/29/2013 21:17,Clay at Battery,41,582,Customer,10014
+4503,728,8/29/2013 13:29,2nd at South Park,64,8/29/2013 13:41,Embarcadero at Vallejo,48,331,Subscriber,94110
+4823,733,8/29/2013 17:37,5th at Howard,57,8/29/2013 17:50,Market at 10th,67,633,Customer,94062
+4979,747,8/29/2013 19:40,Harry Bridges Plaza (Ferry Building),50,8/29/2013 19:52,Civic Center BART (7th at Market),72,337,Subscriber,94117
+4586,748,8/29/2013 14:17,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 14:30,Powell Street BART,39,541,Customer,
+4425,752,8/29/2013 12:51,Mechanics Plaza (Market at Battery),75,8/29/2013 13:04,Mechanics Plaza (Market at Battery),75,586,Subscriber,94117
+4545,752,8/29/2013 13:50,Commercial at Montgomery,45,8/29/2013 14:02,Embarcadero at Sansome,60,461,Customer,2142
+4652,753,8/29/2013 15:28,Grant Avenue at Columbus Avenue,73,8/29/2013 15:40,Yerba Buena Center of the Arts (3rd @ Howard),68,504,Customer,94025
+5083,755,8/29/2013 22:05,2nd at South Park,64,8/29/2013 22:18,Harry Bridges Plaza (Ferry Building),50,270,Subscriber,94105
+4842,756,8/29/2013 17:48,Redwood City Caltrain Station,22,8/29/2013 18:01,Franklin at Maple,21,159,Subscriber,94070
+5045,757,8/29/2013 20:51,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 21:03,San Francisco Caltrain 2 (330 Townsend),69,416,Subscriber,94109
+4277,759,8/29/2013 11:50,San Francisco City Hall,58,8/29/2013 12:03,Post at Kearney,47,514,Subscriber,94117
+4670,759,8/29/2013 15:40,Golden Gate at Polk,59,8/29/2013 15:53,Market at Sansome,77,539,Customer,94112
+4288,760,8/29/2013 11:57,Spear at Folsom,49,8/29/2013 12:10,Market at 4th,76,562,Subscriber,94110
+4519,763,8/29/2013 13:36,Japantown,9,8/29/2013 13:48,San Pedro Square,6,657,Customer,95020
+4080,764,8/29/2013 9:36,South Van Ness at Market,66,8/29/2013 9:49,San Francisco Caltrain 2 (330 Townsend),69,315,Subscriber,94117
+4803,764,8/29/2013 17:24,Market at Sansome,77,8/29/2013 17:37,South Van Ness at Market,66,539,Subscriber,94114
+4339,765,8/29/2013 12:12,Spear at Folsom,49,8/29/2013 12:25,Harry Bridges Plaza (Ferry Building),50,568,Subscriber,94112
+4340,767,8/29/2013 12:13,University and Emerson,35,8/29/2013 12:26,California Ave Caltrain Station,36,163,Subscriber,94040
+4404,768,8/29/2013 12:40,Powell Street BART,39,8/29/2013 12:53,Civic Center BART (7th at Market),72,430,Subscriber,94117
+4973,768,8/29/2013 19:38,Grant Avenue at Columbus Avenue,73,8/29/2013 19:51,Post at Kearney,47,442,Customer,2151
+4832,776,8/29/2013 17:44,Market at Sansome,77,8/29/2013 17:57,San Francisco Caltrain (Townsend at 4th),70,613,Subscriber,94070
+4444,777,8/29/2013 12:57,MLK Library,11,8/29/2013 13:10,San Jose Diridon Caltrain Station,2,107,Subscriber,95126
+4703,778,8/29/2013 16:15,Harry Bridges Plaza (Ferry Building),50,8/29/2013 16:28,Market at 4th,76,584,Subscriber,94122
+4838,778,8/29/2013 17:46,Mountain View Caltrain Station,28,8/29/2013 17:59,Mountain View City Hall,27,129,Customer,94040
+4851,783,8/29/2013 17:55,Beale at Market,56,8/29/2013 18:08,Grant Avenue at Columbus Avenue,73,442,Subscriber,94597
+4358,784,8/29/2013 12:20,Embarcadero at Folsom,51,8/29/2013 12:33,Beale at Market,56,273,Subscriber,94597
+4877,792,8/29/2013 18:09,Post at Kearney,47,8/29/2013 18:23,South Van Ness at Market,66,622,Subscriber,94110
+4671,797,8/29/2013 15:44,South Van Ness at Market,66,8/29/2013 15:57,Market at Sansome,77,267,Subscriber,94945
+4945,797,8/29/2013 19:08,2nd at Folsom,62,8/29/2013 19:21,Embarcadero at Vallejo,48,406,Customer,94105
+4752,799,8/29/2013 16:58,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 17:11,Townsend at 7th,65,504,Subscriber,94107
+4899,802,8/29/2013 18:24,Embarcadero at Bryant,54,8/29/2013 18:37,Temporary Transbay Terminal (Howard at Beale),55,376,Subscriber,94404
+4702,804,8/29/2013 16:14,Harry Bridges Plaza (Ferry Building),50,8/29/2013 16:27,Market at 4th,76,592,Subscriber,94061
+4739,809,8/29/2013 16:44,Post at Kearney,47,8/29/2013 16:58,Embarcadero at Sansome,60,616,Customer,94117
+5079,809,8/29/2013 22:01,Embarcadero at Vallejo,48,8/29/2013 22:14,Clay at Battery,41,538,Customer,8540
+4736,812,8/29/2013 16:42,Townsend at 7th,65,8/29/2013 16:56,Townsend at 7th,65,395,Customer,77520
+5012,812,8/29/2013 20:13,Harry Bridges Plaza (Ferry Building),50,8/29/2013 20:26,Embarcadero at Sansome,60,448,Customer,85224
+4820,813,8/29/2013 17:35,2nd at Folsom,62,8/29/2013 17:48,Townsend at 7th,65,409,Subscriber,94107
+4873,813,8/29/2013 18:07,Temporary Transbay Terminal (Howard at Beale),55,8/29/2013 18:20,Grant Avenue at Columbus Avenue,73,353,Customer,
+4526,814,8/29/2013 13:39,Market at 4th,76,8/29/2013 13:53,South Van Ness at Market,66,431,Subscriber,94127
+4939,816,8/29/2013 19:01,2nd at Folsom,62,8/29/2013 19:14,Harry Bridges Plaza (Ferry Building),50,539,Subscriber,94103
+4541,817,8/29/2013 13:49,Embarcadero at Vallejo,48,8/29/2013 14:03,Market at Sansome,77,488,Subscriber,94608
+5030,818,8/29/2013 20:29,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 20:43,Clay at Battery,41,544,Customer,10010
+4681,819,8/29/2013 15:55,Post at Kearney,47,8/29/2013 16:09,Powell at Post (Union Square),71,373,Subscriber,94122
+4390,825,8/29/2013 12:33,2nd at Folsom,62,8/29/2013 12:47,2nd at South Park,64,331,Subscriber,94518
+4685,826,8/29/2013 15:58,Clay at Battery,41,8/29/2013 16:12,Civic Center BART (7th at Market),72,315,Customer,90019
+4931,826,8/29/2013 18:56,Powell at Post (Union Square),71,8/29/2013 19:10,Yerba Buena Center of the Arts (3rd @ Howard),68,466,Customer,
+4946,827,8/29/2013 19:07,2nd at Folsom,62,8/29/2013 19:21,Embarcadero at Vallejo,48,342,Customer,94105
+4701,828,8/29/2013 16:14,Harry Bridges Plaza (Ferry Building),50,8/29/2013 16:27,Market at 4th,76,372,Subscriber,94122
+4591,832,8/29/2013 14:30,San Salvador at 1st,8,8/29/2013 14:43,St James Park,13,188,Subscriber,95112
+4451,834,8/29/2013 13:02,Harry Bridges Plaza (Ferry Building),50,8/29/2013 13:16,Clay at Battery,41,618,Subscriber,94115
+5011,834,8/29/2013 20:13,Harry Bridges Plaza (Ferry Building),50,8/29/2013 20:26,Embarcadero at Sansome,60,327,Customer,85224
+4972,837,8/29/2013 19:38,Grant Avenue at Columbus Avenue,73,8/29/2013 19:52,Post at Kearney,47,408,Customer,96001
+4938,840,8/29/2013 19:01,2nd at Folsom,62,8/29/2013 19:15,Harry Bridges Plaza (Ferry Building),50,607,Subscriber,94103
+4997,841,8/29/2013 19:57,San Jose Diridon Caltrain Station,2,8/29/2013 20:11,San Jose City Hall,10,58,Subscriber,95112
+4523,844,8/29/2013 13:38,Market at 4th,76,8/29/2013 13:53,South Van Ness at Market,66,489,Subscriber,94127
+4857,844,8/29/2013 17:58,South Van Ness at Market,66,8/29/2013 18:12,2nd at Folsom,62,607,Subscriber,94103
+4756,845,8/29/2013 17:00,Spear at Folsom,49,8/29/2013 17:14,San Francisco Caltrain (Townsend at 4th),70,381,Subscriber,94010
+4858,845,8/29/2013 17:58,South Van Ness at Market,66,8/29/2013 18:12,2nd at Folsom,62,539,Subscriber,94103
+4853,849,8/29/2013 17:55,Townsend at 7th,65,8/29/2013 18:09,San Francisco City Hall,58,411,Customer,94118
+4507,850,8/29/2013 13:31,Commercial at Montgomery,45,8/29/2013 13:45,Market at 10th,67,392,Subscriber,10009
+4645,850,8/29/2013 15:20,2nd at South Park,64,8/29/2013 15:35,San Francisco Caltrain (Townsend at 4th),70,288,Subscriber,94109
+4544,852,8/29/2013 13:49,California Ave Caltrain Station,36,8/29/2013 14:03,Cowper at University,37,20,Customer,94306
+4774,852,8/29/2013 17:08,Market at Sansome,77,8/29/2013 17:22,South Van Ness at Market,66,375,Subscriber,94122
+4975,852,8/29/2013 19:39,Grant Avenue at Columbus Avenue,73,8/29/2013 19:53,Commercial at Montgomery,45,625,Subscriber,94131
+4380,853,8/29/2013 12:29,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 12:44,Market at 10th,67,574,Subscriber,94127
+4964,853,8/29/2013 19:32,Mechanics Plaza (Market at Battery),75,8/29/2013 19:46,Townsend at 7th,65,378,Customer,94109
+5026,857,8/29/2013 20:27,Townsend at 7th,65,8/29/2013 20:42,Townsend at 7th,65,345,Subscriber,94107
+4614,863,8/29/2013 14:52,Howard at 2nd,63,8/29/2013 15:06,Market at 10th,67,351,Subscriber,94612
+4620,865,8/29/2013 14:58,Howard at 2nd,63,8/29/2013 15:13,Yerba Buena Center of the Arts (3rd @ Howard),68,348,Subscriber,94114
+4593,867,8/29/2013 14:30,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 14:44,San Francisco City Hall,58,267,Subscriber,94115
+4846,867,8/29/2013 17:51,Commercial at Montgomery,45,8/29/2013 18:05,Commercial at Montgomery,45,324,Customer,94102
+4869,870,8/29/2013 18:06,Spear at Folsom,49,8/29/2013 18:21,5th at Howard,57,404,Subscriber,94105
+4391,873,8/29/2013 12:33,South Van Ness at Market,66,8/29/2013 12:48,Townsend at 7th,65,369,Subscriber,94549
+4352,874,8/29/2013 12:16,South Van Ness at Market,66,8/29/2013 12:31,Market at Sansome,77,387,Subscriber,94117
+4974,877,8/29/2013 19:38,Grant Avenue at Columbus Avenue,73,8/29/2013 19:53,Commercial at Montgomery,45,636,Subscriber,94131
+4713,878,8/29/2013 16:20,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 16:35,South Van Ness at Market,66,431,Customer,94102
+4804,878,8/29/2013 17:24,Embarcadero at Sansome,60,8/29/2013 17:39,Beale at Market,56,395,Customer,77520
+4907,879,8/29/2013 18:31,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 18:46,Commercial at Montgomery,45,579,Subscriber,94102
+4940,879,8/29/2013 19:03,Beale at Market,56,8/29/2013 19:17,South Van Ness at Market,66,395,Subscriber,94102
+4375,880,8/29/2013 12:26,California Ave Caltrain Station,36,8/29/2013 12:41,University and Emerson,35,161,Subscriber,94040
+4573,882,8/29/2013 14:09,San Salvador at 1st,8,8/29/2013 14:24,San Salvador at 1st,8,188,Subscriber,95112
+4654,882,8/29/2013 15:28,Civic Center BART (7th at Market),72,8/29/2013 15:43,Townsend at 7th,65,615,Subscriber,94112
+4275,883,8/29/2013 11:43,Mechanics Plaza (Market at Battery),75,8/29/2013 11:57,South Van Ness at Market,66,626,Subscriber,94107
+4395,885,8/29/2013 12:35,Grant Avenue at Columbus Avenue,73,8/29/2013 12:49,Post at Kearney,47,505,Customer,94108
+4935,885,8/29/2013 18:57,Howard at 2nd,63,8/29/2013 19:12,South Van Ness at Market,66,360,Subscriber,94110
+5090,892,8/29/2013 22:11,Grant Avenue at Columbus Avenue,73,8/29/2013 22:26,Townsend at 7th,65,634,Customer,94107
+4737,897,8/29/2013 16:43,South Van Ness at Market,66,8/29/2013 16:58,Powell Street BART,39,416,Customer,94110
+4319,899,8/29/2013 12:10,South Van Ness at Market,66,8/29/2013 12:25,Beale at Market,56,546,Subscriber,94107
+4991,902,8/29/2013 19:48,Market at 10th,67,8/29/2013 20:03,Market at 4th,76,536,Subscriber,94110
+4734,905,8/29/2013 16:41,South Van Ness at Market,66,8/29/2013 16:56,Harry Bridges Plaza (Ferry Building),50,448,Subscriber,94122
+4781,908,8/29/2013 17:12,Commercial at Montgomery,45,8/29/2013 17:27,2nd at Townsend,61,621,Customer,94158
+4214,909,8/29/2013 11:15,Grant Avenue at Columbus Avenue,73,8/29/2013 11:30,Post at Kearney,47,476,Customer,20002
+5027,912,8/29/2013 20:28,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 20:43,Clay at Battery,41,514,Customer,10012
+4494,913,8/29/2013 13:19,Commercial at Montgomery,45,8/29/2013 13:34,Market at 10th,67,506,Customer,
+4742,914,8/29/2013 16:47,Steuart at Market,74,8/29/2013 17:02,San Francisco Caltrain (Townsend at 4th),70,511,Subscriber,94111
+4690,918,8/29/2013 16:01,Harry Bridges Plaza (Ferry Building),50,8/29/2013 16:16,Embarcadero at Sansome,60,395,Customer,77520
+4618,919,8/29/2013 14:58,South Van Ness at Market,66,8/29/2013 15:13,San Francisco Caltrain 2 (330 Townsend),69,489,Subscriber,94556
+4449,926,8/29/2013 13:01,Embarcadero at Sansome,60,8/29/2013 13:16,Embarcadero at Vallejo,48,579,Customer,
+4976,926,8/29/2013 19:39,Clay at Battery,41,8/29/2013 19:55,San Francisco Caltrain 2 (330 Townsend),69,544,Customer,94107
+4845,929,8/29/2013 17:50,Powell Street BART,39,8/29/2013 18:05,San Francisco Caltrain (Townsend at 4th),70,574,Customer,
+4213,931,8/29/2013 11:14,Grant Avenue at Columbus Avenue,73,8/29/2013 11:30,Post at Kearney,47,473,Customer,20002
+4764,931,8/29/2013 17:04,MLK Library,11,8/29/2013 17:19,San Jose Diridon Caltrain Station,2,91,Customer,94110
+5000,932,8/29/2013 19:59,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 20:15,South Van Ness at Market,66,444,Customer,94702
+4971,936,8/29/2013 19:36,Grant Avenue at Columbus Avenue,73,8/29/2013 19:52,Market at 4th,76,309,Subscriber,94597
+4617,939,8/29/2013 14:57,South Van Ness at Market,66,8/29/2013 15:13,San Francisco Caltrain 2 (330 Townsend),69,431,Subscriber,94618
+4926,941,8/29/2013 18:53,5th at Howard,57,8/29/2013 19:09,San Francisco Caltrain (Townsend at 4th),70,521,Customer,94158
+4925,943,8/29/2013 18:53,5th at Howard,57,8/29/2013 19:09,San Francisco Caltrain (Townsend at 4th),70,334,Customer,94158
+4780,948,8/29/2013 17:11,Market at Sansome,77,8/29/2013 17:27,South Van Ness at Market,66,607,Subscriber,94117
+4453,949,8/29/2013 13:04,Embarcadero at Sansome,60,8/29/2013 13:20,Commercial at Montgomery,45,461,Customer,94109
+4397,950,8/29/2013 12:36,2nd at Townsend,61,8/29/2013 12:52,Steuart at Market,74,312,Customer,95819
+4601,953,8/29/2013 14:33,San Antonio Caltrain Station,29,8/29/2013 14:49,Mountain View Caltrain Station,28,165,Subscriber,94301
+4497,954,8/29/2013 13:19,Harry Bridges Plaza (Ferry Building),50,8/29/2013 13:35,San Francisco Caltrain (Townsend at 4th),70,568,Customer,94597
+4771,956,8/29/2013 17:07,Market at Sansome,77,8/29/2013 17:23,South Van Ness at Market,66,514,Customer,10514
+4683,960,8/29/2013 15:57,Commercial at Montgomery,45,8/29/2013 16:13,South Van Ness at Market,66,435,Subscriber,94102
+4633,963,8/29/2013 15:09,Howard at 2nd,63,8/29/2013 15:25,Golden Gate at Polk,59,388,Customer,94112
+4687,967,8/29/2013 16:00,Embarcadero at Vallejo,48,8/29/2013 16:16,Market at Sansome,77,514,Customer,10514
+4585,968,8/29/2013 14:17,San Francisco City Hall,58,8/29/2013 14:33,2nd at South Park,64,438,Subscriber,94110
+4289,970,8/29/2013 11:58,Steuart at Market,74,8/29/2013 12:14,Steuart at Market,74,570,Subscriber,94109
+4943,970,8/29/2013 19:06,Davis at Jackson,42,8/29/2013 19:22,Golden Gate at Polk,59,421,Subscriber,94111
+4886,971,8/29/2013 18:14,Spear at Folsom,49,8/29/2013 18:31,Civic Center BART (7th at Market),72,345,Subscriber,94117
+4665,972,8/29/2013 15:36,San Pedro Square,6,8/29/2013 15:52,San Pedro Square,6,146,Subscriber,94041
+4740,976,8/29/2013 16:45,Embarcadero at Bryant,54,8/29/2013 17:01,Post at Kearney,47,284,Customer,2142
+5041,976,8/29/2013 20:42,Townsend at 7th,65,8/29/2013 20:58,Townsend at 7th,65,347,Subscriber,94107
+4210,980,8/29/2013 11:13,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 11:30,South Van Ness at Market,66,319,Subscriber,94118
+4431,980,8/29/2013 12:54,Powell at Post (Union Square),71,8/29/2013 13:10,Post at Kearney,47,507,Subscriber,94109
+4757,981,8/29/2013 17:00,Beale at Market,56,8/29/2013 17:17,Embarcadero at Sansome,60,273,Customer,43214
+4426,982,8/29/2013 12:52,2nd at South Park,64,8/29/2013 13:08,2nd at South Park,64,593,Subscriber,94117
+4569,987,8/29/2013 14:06,South Van Ness at Market,66,8/29/2013 14:22,Steuart at Market,74,317,Customer,94102
+4790,989,8/29/2013 17:17,Market at 10th,67,8/29/2013 17:34,Steuart at Market,74,598,Customer,94597
+5038,994,8/29/2013 20:36,San Jose Diridon Caltrain Station,2,8/29/2013 20:53,SJSU 4th at San Carlos,12,91,Subscriber,95126
+4079,995,8/29/2013 9:35,South Van Ness at Market,66,8/29/2013 9:52,South Van Ness at Market,66,327,Subscriber,94102
+4984,998,8/29/2013 19:43,Embarcadero at Folsom,51,8/29/2013 19:59,Grant Avenue at Columbus Avenue,73,260,Subscriber,94105
+4635,999,8/29/2013 15:09,Embarcadero at Sansome,60,8/29/2013 15:26,Steuart at Market,74,461,Customer,32836
+4308,1000,8/29/2013 12:04,Redwood City Caltrain Station,22,8/29/2013 12:21,Redwood City Caltrain Station,22,159,Subscriber,94061
+4983,1009,8/29/2013 19:42,Embarcadero at Folsom,51,8/29/2013 19:59,Grant Avenue at Columbus Avenue,73,265,Subscriber,94105
+4948,1010,8/29/2013 19:10,Embarcadero at Sansome,60,8/29/2013 19:27,Powell at Post (Union Square),71,492,Customer,94609
+4568,1013,8/29/2013 14:06,South Van Ness at Market,66,8/29/2013 14:22,Steuart at Market,74,525,Customer,94102
+4491,1015,8/29/2013 13:18,Townsend at 7th,65,8/29/2013 13:35,South Van Ness at Market,66,438,Subscriber,94549
+4861,1015,8/29/2013 18:00,Post at Kearney,47,8/29/2013 18:17,Golden Gate at Polk,59,498,Subscriber,94118
+4862,1015,8/29/2013 18:00,Post at Kearney,47,8/29/2013 18:17,Golden Gate at Polk,59,610,Subscriber,94118
+5007,1016,8/29/2013 20:11,Rengstorff Avenue / California Street,33,8/29/2013 20:28,Rengstorff Avenue / California Street,33,11,Customer,94040
+4512,1024,8/29/2013 13:32,Harry Bridges Plaza (Ferry Building),50,8/29/2013 13:49,Embarcadero at Vallejo,48,314,Subscriber,94608
+4746,1024,8/29/2013 16:53,Harry Bridges Plaza (Ferry Building),50,8/29/2013 17:11,Market at 10th,67,617,Subscriber,94134
+4813,1030,8/29/2013 17:31,Market at 10th,67,8/29/2013 17:48,Embarcadero at Sansome,60,464,Customer,94117
+4254,1032,8/29/2013 11:31,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 11:48,San Francisco Caltrain 2 (330 Townsend),69,541,Customer,94117
+4121,1040,8/29/2013 10:13,University and Emerson,35,8/29/2013 10:31,California Ave Caltrain Station,36,13,Subscriber,94303
+4485,1040,8/29/2013 13:16,Commercial at Montgomery,45,8/29/2013 13:34,Market at 10th,67,410,Customer,94117
+4775,1046,8/29/2013 17:08,Spear at Folsom,49,8/29/2013 17:26,Embarcadero at Sansome,60,343,Customer,94607
+4688,1047,8/29/2013 16:00,Spear at Folsom,49,8/29/2013 16:17,Civic Center BART (7th at Market),72,347,Customer,94109
+4438,1050,8/29/2013 12:55,Harry Bridges Plaza (Ferry Building),50,8/29/2013 13:12,Market at Sansome,77,594,Customer,94709
+4437,1052,8/29/2013 12:55,Harry Bridges Plaza (Ferry Building),50,8/29/2013 13:12,Market at Sansome,77,578,Subscriber,94110
+4268,1055,8/29/2013 11:40,Market at 10th,67,8/29/2013 11:57,Beale at Market,56,324,Subscriber,94127
+4852,1055,8/29/2013 17:55,Post at Kearney,47,8/29/2013 18:13,Grant Avenue at Columbus Avenue,73,284,Customer,2151
+5091,1061,8/29/2013 22:11,Mountain View City Hall,27,8/29/2013 22:29,Mountain View City Hall,27,56,Subscriber,94041
+4629,1065,8/29/2013 15:03,Davis at Jackson,42,8/29/2013 15:20,South Van Ness at Market,66,356,Subscriber,94127
+4995,1065,8/29/2013 19:53,Market at 10th,67,8/29/2013 20:11,Beale at Market,56,557,Subscriber,94609
+4206,1066,8/29/2013 11:09,Market at 10th,67,8/29/2013 11:27,Steuart at Market,74,632,Customer,98034
+4073,1067,8/29/2013 9:24,South Van Ness at Market,66,8/29/2013 9:42,San Francisco Caltrain 2 (330 Townsend),69,321,Subscriber,94703
+4244,1071,8/29/2013 11:26,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 11:44,San Francisco City Hall,58,572,Subscriber,94122
+4733,1072,8/29/2013 16:40,Post at Kearney,47,8/29/2013 16:58,Embarcadero at Sansome,60,538,Customer,94114
+4956,1072,8/29/2013 19:15,Harry Bridges Plaza (Ferry Building),50,8/29/2013 19:33,South Van Ness at Market,66,510,Subscriber,94103
+5049,1075,8/29/2013 21:00,San Jose Civic Center,3,8/29/2013 21:18,Santa Clara at Almaden,4,68,Customer,
+4555,1077,8/29/2013 13:55,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 14:13,Mechanics Plaza (Market at Battery),75,557,Customer,94702
+4888,1077,8/29/2013 18:16,2nd at Townsend,61,8/29/2013 18:34,Grant Avenue at Columbus Avenue,73,309,Customer,94121
+4580,1081,8/29/2013 14:14,South Van Ness at Market,66,8/29/2013 14:32,Harry Bridges Plaza (Ferry Building),50,370,Subscriber,94127
+4373,1083,8/29/2013 12:22,Palo Alto Caltrain Station,34,8/29/2013 12:40,University and Emerson,35,83,Subscriber,94117
+4433,1083,8/29/2013 12:54,Harry Bridges Plaza (Ferry Building),50,8/29/2013 13:12,Market at Sansome,77,613,Subscriber,94109
+4511,1088,8/29/2013 13:32,California Ave Caltrain Station,36,8/29/2013 13:50,University and Emerson,35,93,Customer,10003
+4847,1088,8/29/2013 17:51,Mechanics Plaza (Market at Battery),75,8/29/2013 18:09,Market at 10th,67,557,Subscriber,94109
+4365,1094,8/29/2013 12:24,Arena Green / SAP Center,14,8/29/2013 12:42,Arena Green / SAP Center,14,647,Subscriber,95126
+5068,1096,8/29/2013 21:40,Embarcadero at Vallejo,48,8/29/2013 21:58,Civic Center BART (7th at Market),72,571,Customer,
+4916,1097,8/29/2013 18:45,Steuart at Market,74,8/29/2013 19:03,South Van Ness at Market,66,598,Subscriber,94111
+4826,1098,8/29/2013 17:38,Commercial at Montgomery,45,8/29/2013 17:57,San Francisco Caltrain (Townsend at 4th),70,384,Subscriber,94107
+4767,1101,8/29/2013 17:05,Townsend at 7th,65,8/29/2013 17:23,Embarcadero at Sansome,60,395,Customer,77520
+4279,1105,8/29/2013 11:53,Post at Kearney,47,8/29/2013 12:12,Post at Kearney,47,602,Subscriber,94114
+4432,1107,8/29/2013 12:54,Harry Bridges Plaza (Ferry Building),50,8/29/2013 13:13,Market at Sansome,77,333,Subscriber,94110
+5048,1107,8/29/2013 21:00,San Jose Civic Center,3,8/29/2013 21:18,Santa Clara at Almaden,4,188,Customer,
+4821,1109,8/29/2013 17:36,Market at 10th,67,8/29/2013 17:55,San Francisco Caltrain (Townsend at 4th),70,392,Subscriber,94134
+4307,1110,8/29/2013 12:04,Mechanics Plaza (Market at Battery),75,8/29/2013 12:23,Mechanics Plaza (Market at Battery),75,600,Subscriber,94109
+4509,1111,8/29/2013 13:31,California Ave Caltrain Station,36,8/29/2013 13:50,University and Emerson,35,87,Customer,10003
+4993,1112,8/29/2013 19:53,Embarcadero at Folsom,51,8/29/2013 20:11,Embarcadero at Sansome,60,330,Subscriber,94105
+4075,1117,8/29/2013 9:24,South Van Ness at Market,66,8/29/2013 9:43,San Francisco Caltrain 2 (330 Townsend),69,316,Subscriber,94122
+4076,1118,8/29/2013 9:25,South Van Ness at Market,66,8/29/2013 9:43,San Francisco Caltrain 2 (330 Townsend),69,322,Subscriber,94597
+4727,1126,8/29/2013 16:35,Embarcadero at Sansome,60,8/29/2013 16:54,Washington at Kearney,46,556,Customer,19714
+4484,1127,8/29/2013 13:16,Commercial at Montgomery,45,8/29/2013 13:35,Market at 10th,67,416,Subscriber,94703
+4682,1129,8/29/2013 15:55,Clay at Battery,41,8/29/2013 16:14,San Francisco Caltrain (Townsend at 4th),70,382,Customer,94115
+4074,1131,8/29/2013 9:24,South Van Ness at Market,66,8/29/2013 9:43,San Francisco Caltrain 2 (330 Townsend),69,317,Subscriber,94115
+4819,1133,8/29/2013 17:34,University and Emerson,35,8/29/2013 17:52,California Ave Caltrain Station,36,16,Customer,10003
+4487,1136,8/29/2013 13:17,Commercial at Montgomery,45,8/29/2013 13:35,Market at 10th,67,448,Subscriber,94609
+4708,1137,8/29/2013 16:16,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 16:35,San Francisco Caltrain (Townsend at 4th),70,580,Customer,94115
+4707,1138,8/29/2013 16:16,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 16:35,San Francisco Caltrain (Townsend at 4th),70,602,Customer,94115
+4726,1140,8/29/2013 16:35,Embarcadero at Sansome,60,8/29/2013 16:54,Washington at Kearney,46,493,Customer,19714
+4747,1140,8/29/2013 16:55,Townsend at 7th,65,8/29/2013 17:14,Powell Street BART,39,632,Subscriber,94805
+4712,1142,8/29/2013 16:20,Embarcadero at Sansome,60,8/29/2013 16:39,Townsend at 7th,65,395,Customer,77520
+4843,1147,8/29/2013 17:50,Market at Sansome,77,8/29/2013 18:09,Mechanics Plaza (Market at Battery),75,547,Customer,94112
+5094,1149,8/29/2013 22:13,Spear at Folsom,49,8/29/2013 22:33,Grant Avenue at Columbus Avenue,73,283,Customer,92648
+4219,1150,8/29/2013 11:18,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 11:37,Civic Center BART (7th at Market),72,597,Subscriber,97214
+4692,1150,8/29/2013 16:02,Beale at Market,56,8/29/2013 16:21,South Van Ness at Market,66,320,Subscriber,94107
+4658,1152,8/29/2013 15:31,Commercial at Montgomery,45,8/29/2013 15:50,Commercial at Montgomery,45,435,Customer,94122
+4664,1157,8/29/2013 15:35,Market at Sansome,77,8/29/2013 15:54,Market at Sansome,77,470,Customer,94112
+4359,1159,8/29/2013 12:21,South Van Ness at Market,66,8/29/2013 12:40,Steuart at Market,74,516,Subscriber,94121
+4856,1159,8/29/2013 17:57,Embarcadero at Vallejo,48,8/29/2013 18:16,South Van Ness at Market,66,491,Subscriber,94114
+4479,1161,8/29/2013 13:16,Commercial at Montgomery,45,8/29/2013 13:35,Market at 10th,67,379,Subscriber,94122
+4345,1162,8/29/2013 12:14,Market at 10th,67,8/29/2013 12:33,Commercial at Montgomery,45,319,Subscriber,94103
+4900,1168,8/29/2013 18:25,Market at 4th,76,8/29/2013 18:45,Embarcadero at Sansome,60,377,Customer,
+5056,1171,8/29/2013 21:09,Clay at Battery,41,8/29/2013 21:29,Embarcadero at Bryant,54,538,Customer,8540
+5039,1174,8/29/2013 20:42,Grant Avenue at Columbus Avenue,73,8/29/2013 21:02,Embarcadero at Folsom,51,260,Subscriber,94105
+4680,1176,8/29/2013 15:55,Clay at Battery,41,8/29/2013 16:14,San Francisco Caltrain (Townsend at 4th),70,619,Customer,94115
+4693,1177,8/29/2013 16:03,Mechanics Plaza (Market at Battery),75,8/29/2013 16:23,Market at Sansome,77,586,Customer,94112
+4818,1177,8/29/2013 17:33,University and Emerson,35,8/29/2013 17:53,California Ave Caltrain Station,36,87,Customer,10003
+4992,1189,8/29/2013 19:52,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 20:12,Powell Street BART,39,574,Customer,95014
+4311,1191,8/29/2013 12:05,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 12:25,Mechanics Plaza (Market at Battery),75,518,Customer,94158
+4619,1201,8/29/2013 14:58,South Van Ness at Market,66,8/29/2013 15:18,Beale at Market,56,587,Subscriber,94114
+4506,1206,8/29/2013 13:31,California Ave Caltrain Station,36,8/29/2013 13:51,Palo Alto Caltrain Station,34,163,Subscriber,94301
+4954,1210,8/29/2013 19:15,Harry Bridges Plaza (Ferry Building),50,8/29/2013 19:35,South Van Ness at Market,66,394,Subscriber,94103
+4372,1211,8/29/2013 12:25,Market at 4th,76,8/29/2013 12:45,Embarcadero at Sansome,60,459,Customer,20002
+4515,1211,8/29/2013 13:33,Steuart at Market,74,8/29/2013 13:53,San Francisco City Hall,58,623,Customer,
+4116,1213,8/29/2013 10:11,University and Emerson,35,8/29/2013 10:32,California Ave Caltrain Station,36,83,Subscriber,95112
+4909,1220,8/29/2013 18:36,5th at Howard,57,8/29/2013 18:57,Embarcadero at Vallejo,48,404,Subscriber,94103
+4514,1224,8/29/2013 13:33,Steuart at Market,74,8/29/2013 13:53,San Francisco City Hall,58,632,Customer,
+4368,1241,8/29/2013 12:25,Market at 4th,76,8/29/2013 12:45,Embarcadero at Sansome,60,488,Customer,20002
+4891,1244,8/29/2013 18:20,Harry Bridges Plaza (Ferry Building),50,8/29/2013 18:41,Harry Bridges Plaza (Ferry Building),50,510,Customer,94707
+4966,1245,8/29/2013 19:32,Post at Kearney,47,8/29/2013 19:53,San Francisco Caltrain (Townsend at 4th),70,535,Customer,94123
+4735,1247,8/29/2013 16:41,Market at Sansome,77,8/29/2013 17:02,Embarcadero at Sansome,60,267,Customer,60614
+4672,1251,8/29/2013 15:44,Harry Bridges Plaza (Ferry Building),50,8/29/2013 16:05,San Francisco Caltrain (Townsend at 4th),70,583,Subscriber,94122
+5040,1253,8/29/2013 20:42,Grant Avenue at Columbus Avenue,73,8/29/2013 21:03,Embarcadero at Folsom,51,265,Subscriber,94105
+5092,1253,8/29/2013 22:12,Spear at Folsom,49,8/29/2013 22:33,Grant Avenue at Columbus Avenue,73,282,Customer,78209
+4827,1258,8/29/2013 17:38,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 17:59,Post at Kearney,47,381,Subscriber,94118
+4913,1263,8/29/2013 18:41,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 19:02,Market at 4th,76,511,Subscriber,94109
+4160,1271,8/29/2013 10:42,San Jose City Hall,10,8/29/2013 11:03,San Jose City Hall,10,680,Subscriber,95112
+4164,1276,8/29/2013 10:47,San Jose City Hall,10,8/29/2013 11:09,San Jose City Hall,10,30,Subscriber,95060
+5103,1278,8/29/2013 22:54,Embarcadero at Folsom,51,8/29/2013 23:16,Embarcadero at Sansome,60,260,Subscriber,94105
+4662,1279,8/29/2013 15:33,Market at Sansome,77,8/29/2013 15:55,Market at Sansome,77,375,Customer,94117
+4284,1281,8/29/2013 11:55,Harry Bridges Plaza (Ferry Building),50,8/29/2013 12:17,Embarcadero at Sansome,60,584,Customer,
+4546,1288,8/29/2013 13:52,Steuart at Market,74,8/29/2013 14:13,Embarcadero at Sansome,60,570,Customer,95819
+4305,1292,8/29/2013 12:04,San Francisco City Hall,58,8/29/2013 12:25,Steuart at Market,74,634,Customer,
+4351,1298,8/29/2013 12:16,Market at 10th,67,8/29/2013 12:37,Clay at Battery,41,496,Customer,
+4457,1301,8/29/2013 13:05,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 13:27,Embarcadero at Vallejo,48,327,Customer,77459
+4303,1305,8/29/2013 12:03,San Francisco City Hall,58,8/29/2013 12:25,Steuart at Market,74,523,Customer,
+4656,1306,8/29/2013 15:29,Harry Bridges Plaza (Ferry Building),50,8/29/2013 15:51,San Francisco Caltrain (Townsend at 4th),70,602,Customer,94102
+4394,1309,8/29/2013 12:34,SJSU 4th at San Carlos,12,8/29/2013 12:56,San Salvador at 1st,8,46,Subscriber,95112
+4924,1313,8/29/2013 18:52,St James Park,13,8/29/2013 19:14,San Salvador at 1st,8,25,Subscriber,95112
+4461,1314,8/29/2013 13:07,Davis at Jackson,42,8/29/2013 13:29,Market at 10th,67,598,Subscriber,94121
+4335,1321,8/29/2013 12:11,Market at 4th,76,8/29/2013 12:33,Embarcadero at Vallejo,48,494,Customer,
+4963,1323,8/29/2013 19:24,Embarcadero at Vallejo,48,8/29/2013 19:46,South Van Ness at Market,66,342,Customer,94117
+4866,1326,8/29/2013 18:03,Grant Avenue at Columbus Avenue,73,8/29/2013 18:25,South Van Ness at Market,66,443,Subscriber,94122
+4895,1326,8/29/2013 18:23,Market at 4th,76,8/29/2013 18:45,Embarcadero at Sansome,60,538,Customer,
+4328,1328,8/29/2013 12:11,Market at 10th,67,8/29/2013 12:33,Commercial at Montgomery,45,448,Subscriber,94122
+4923,1329,8/29/2013 18:52,St James Park,13,8/29/2013 19:14,San Salvador at 1st,8,70,Subscriber,95112
+4759,1339,8/29/2013 17:01,Market at Sansome,77,8/29/2013 17:23,South Van Ness at Market,66,614,Customer,10514
+4947,1339,8/29/2013 19:08,Embarcadero at Sansome,60,8/29/2013 19:30,Embarcadero at Bryant,54,512,Subscriber,94115
+5037,1345,8/29/2013 20:36,Japantown,9,8/29/2013 20:59,San Jose Civic Center,3,68,Customer,
+4293,1346,8/29/2013 12:00,Harry Bridges Plaza (Ferry Building),50,8/29/2013 12:22,Embarcadero at Sansome,60,579,Customer,39110
+4653,1349,8/29/2013 15:29,Harry Bridges Plaza (Ferry Building),50,8/29/2013 15:51,San Francisco Caltrain (Townsend at 4th),70,580,Customer,94102
+4252,1350,8/29/2013 11:30,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 11:52,Embarcadero at Vallejo,48,321,Subscriber,94114
+4234,1351,8/29/2013 11:19,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 11:42,South Van Ness at Market,66,317,Subscriber,94124
+4292,1373,8/29/2013 11:59,Harry Bridges Plaza (Ferry Building),50,8/29/2013 12:22,Embarcadero at Sansome,60,356,Customer,39110
+4332,1373,8/29/2013 12:12,Market at 10th,67,8/29/2013 12:35,Commercial at Montgomery,45,416,Subscriber,94703
+4100,1392,8/29/2013 9:57,South Van Ness at Market,66,8/29/2013 10:20,San Francisco Caltrain 2 (330 Townsend),69,319,Subscriber,94118
+4323,1397,8/29/2013 12:10,South Van Ness at Market,66,8/29/2013 12:34,South Van Ness at Market,66,626,Subscriber,94115
+4951,1409,8/29/2013 19:13,2nd at Folsom,62,8/29/2013 19:36,Commercial at Montgomery,45,380,Customer,97330
+5089,1423,8/29/2013 22:09,Spear at Folsom,49,8/29/2013 22:33,Grant Avenue at Columbus Avenue,73,259,Customer,78209
+4769,1424,8/29/2013 17:06,Grant Avenue at Columbus Avenue,73,8/29/2013 17:29,Harry Bridges Plaza (Ferry Building),50,570,Customer,39110
+4950,1424,8/29/2013 19:12,5th at Howard,57,8/29/2013 19:35,Harry Bridges Plaza (Ferry Building),50,508,Subscriber,94707
+4342,1431,8/29/2013 12:13,Market at 10th,67,8/29/2013 12:37,Clay at Battery,41,502,Customer,94117
+4315,1432,8/29/2013 12:07,Townsend at 7th,65,8/29/2013 12:31,5th at Howard,57,538,Customer,37206
+4327,1438,8/29/2013 12:11,Market at 10th,67,8/29/2013 12:35,Washington at Kearney,46,575,Subscriber,94609
+4318,1439,8/29/2013 12:07,Embarcadero at Vallejo,48,8/29/2013 12:31,Harry Bridges Plaza (Ferry Building),50,618,Subscriber,94608
+4534,1439,8/29/2013 13:43,Japantown,9,8/29/2013 14:07,Japantown,9,644,Customer,95125
+4623,1445,8/29/2013 15:01,Embarcadero at Sansome,60,8/29/2013 15:25,Steuart at Market,74,511,Customer,30096
+4297,1451,8/29/2013 12:01,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 12:25,Mechanics Plaza (Market at Battery),75,315,Customer,94158
+4611,1462,8/29/2013 14:46,Post at Kearney,47,8/29/2013 15:11,Embarcadero at Vallejo,48,514,Customer,8053
+4978,1475,8/29/2013 19:40,Paseo de San Antonio,7,8/29/2013 20:04,Paseo de San Antonio,7,143,Subscriber,95113
+4977,1481,8/29/2013 19:40,Paseo de San Antonio,7,8/29/2013 20:04,Paseo de San Antonio,7,676,Subscriber,95113
+4892,1492,8/29/2013 18:21,5th at Howard,57,8/29/2013 18:46,Embarcadero at Vallejo,48,577,Subscriber,94105
+4452,1494,8/29/2013 13:02,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 13:27,Embarcadero at Vallejo,48,259,Customer,77459
+4989,1499,8/29/2013 19:47,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 20:12,Powell at Post (Union Square),71,466,Customer,
+4221,1500,8/29/2013 11:18,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 11:43,South Van Ness at Market,66,546,Subscriber,94123
+5034,1511,8/29/2013 20:34,Japantown,9,8/29/2013 20:59,San Jose Civic Center,3,188,Customer,
+4598,1512,8/29/2013 14:31,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 14:56,Embarcadero at Sansome,60,372,Customer,19714
+4316,1515,8/29/2013 12:07,Post at Kearney,47,8/29/2013 12:32,Post at Kearney,47,514,Subscriber,94122
+4949,1524,8/29/2013 19:11,2nd at Folsom,62,8/29/2013 19:36,Commercial at Montgomery,45,400,Customer,94107
+4217,1535,8/29/2013 11:17,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 11:42,South Van Ness at Market,66,370,Subscriber,94703
+4583,1536,8/29/2013 14:15,Townsend at 7th,65,8/29/2013 14:40,5th at Howard,57,318,Customer,94110
+4988,1539,8/29/2013 19:47,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 20:12,Powell at Post (Union Square),71,487,Customer,94108
+4597,1541,8/29/2013 14:31,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 14:56,Embarcadero at Sansome,60,511,Customer,19714
+5022,1569,8/29/2013 20:24,Embarcadero at Vallejo,48,8/29/2013 20:51,2nd at Townsend,61,338,Customer,94107
+5023,1569,8/29/2013 20:25,Embarcadero at Vallejo,48,8/29/2013 20:51,2nd at Townsend,61,386,Customer,
+4477,1578,8/29/2013 13:14,Market at 10th,67,8/29/2013 13:41,Powell Street BART,39,574,Customer,94107
+4547,1580,8/29/2013 13:52,San Jose Diridon Caltrain Station,2,8/29/2013 14:18,San Jose City Hall,10,107,Customer,94306
+4218,1593,8/29/2013 11:17,San Francisco Caltrain (Townsend at 4th),70,8/29/2013 11:43,South Van Ness at Market,66,377,Subscriber,94114
+4825,1605,8/29/2013 17:38,Embarcadero at Sansome,60,8/29/2013 18:05,Market at 4th,76,538,Customer,43214
+4422,1682,8/29/2013 12:47,Market at 4th,76,8/29/2013 13:15,Embarcadero at Sansome,60,425,Customer,2360
+4567,1684,8/29/2013 14:04,2nd at South Park,64,8/29/2013 14:33,2nd at South Park,64,569,Subscriber,94117
+4564,1693,8/29/2013 14:04,2nd at South Park,64,8/29/2013 14:32,2nd at South Park,64,272,Subscriber,94005
+4566,1699,8/29/2013 14:04,2nd at South Park,64,8/29/2013 14:33,2nd at South Park,64,371,Subscriber,94122
+5053,1701,8/29/2013 21:04,Embarcadero at Folsom,51,8/29/2013 21:32,Embarcadero at Folsom,51,269,Subscriber,94105
+4283,1712,8/29/2013 11:55,Clay at Battery,41,8/29/2013 12:23,Harry Bridges Plaza (Ferry Building),50,544,Subscriber,94070
+4650,1716,8/29/2013 15:26,Harry Bridges Plaza (Ferry Building),50,8/29/2013 15:55,Embarcadero at Vallejo,48,566,Customer,10514
+5052,1719,8/29/2013 21:04,Embarcadero at Folsom,51,8/29/2013 21:33,Embarcadero at Folsom,51,555,Subscriber,94105
+4589,1723,8/29/2013 14:25,Embarcadero at Vallejo,48,8/29/2013 14:54,San Francisco Caltrain (Townsend at 4th),70,562,Customer,77459
+4421,1724,8/29/2013 12:47,Market at 4th,76,8/29/2013 13:16,Embarcadero at Sansome,60,636,Customer,1719
+5063,1725,8/29/2013 21:31,Embarcadero at Bryant,54,8/29/2013 22:00,Embarcadero at Vallejo,48,538,Customer,8540
+4908,1731,8/29/2013 18:34,Embarcadero at Bryant,54,8/29/2013 19:03,Embarcadero at Sansome,60,512,Subscriber,94115
+4588,1751,8/29/2013 14:24,Embarcadero at Vallejo,48,8/29/2013 14:53,San Francisco Caltrain (Townsend at 4th),70,579,Customer,77459
+4402,1776,8/29/2013 12:39,2nd at Townsend,61,8/29/2013 13:09,Embarcadero at Folsom,51,313,Customer,95126
+4960,1790,8/29/2013 19:20,Franklin at Maple,21,8/29/2013 19:50,Franklin at Maple,21,261,Customer,94063
+4364,1800,8/29/2013 12:24,South Van Ness at Market,66,8/29/2013 12:54,Market at Sansome,77,547,Subscriber,10009
+4898,1804,8/29/2013 18:24,Post at Kearney,47,8/29/2013 18:54,Market at 10th,67,536,Customer,94102
+4755,1808,8/29/2013 17:00,Embarcadero at Sansome,60,8/29/2013 17:30,Post at Kearney,47,616,Customer,94114
+4551,1817,8/29/2013 13:54,Palo Alto Caltrain Station,34,8/29/2013 14:24,San Antonio Caltrain Station,29,165,Subscriber,94301
+4753,1830,8/29/2013 16:59,Embarcadero at Sansome,60,8/29/2013 17:30,Post at Kearney,47,427,Customer,94117
+4778,1849,8/29/2013 17:09,Clay at Battery,41,8/29/2013 17:40,Davis at Jackson,42,618,Subscriber,94115
+4919,1879,8/29/2013 18:48,Embarcadero at Sansome,60,8/29/2013 19:19,Davis at Jackson,42,377,Customer,
+4920,1880,8/29/2013 18:48,Embarcadero at Sansome,60,8/29/2013 19:19,Davis at Jackson,42,459,Customer,
+5021,1899,8/29/2013 20:24,Embarcadero at Folsom,51,8/29/2013 20:56,Commercial at Montgomery,45,615,Subscriber,94105
+4495,1901,8/29/2013 13:19,University and Emerson,35,8/29/2013 13:51,University and Emerson,35,168,Subscriber,94303
+4493,1914,8/29/2013 13:19,University and Emerson,35,8/29/2013 13:50,University and Emerson,35,83,Subscriber,94303
+4718,1946,8/29/2013 16:25,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 16:57,Grant Avenue at Columbus Avenue,73,398,Customer,94107
+4501,1963,8/29/2013 13:27,Spear at Folsom,49,8/29/2013 14:00,Spear at Folsom,49,334,Customer,94110
+4133,1965,8/29/2013 10:17,San Francisco Caltrain 2 (330 Townsend),69,8/29/2013 10:50,Powell Street BART,39,316,Customer,
+4957,1969,8/29/2013 19:17,Franklin at Maple,21,8/29/2013 19:50,Franklin at Maple,21,159,Customer,94063
+4844,1970,8/29/2013 17:50,Clay at Battery,41,8/29/2013 18:23,Harry Bridges Plaza (Ferry Building),50,337,Customer,28290
+4355,2044,8/29/2013 12:18,Yerba Buena Center of the Arts (3rd @ Howard),68,8/29/2013 12:52,Yerba Buena Center of the Arts (3rd @ Howard),68,548,Customer,94105
+4894,2069,8/29/2013 18:22,Post at Kearney,47,8/29/2013 18:57,San Francisco City Hall,58,473,Customer,94102
+4575,2096,8/29/2013 14:12,Embarcadero at Sansome,60,8/29/2013 14:47,Grant Avenue at Columbus Avenue,73,636,Customer,
+4241,2124,8/29/2013 11:22,South Van Ness at Market,66,8/29/2013 11:58,Beale at Market,56,320,Subscriber,94103
+4717,2136,8/29/2013 16:24,South Van Ness at Market,66,8/29/2013 17:00,San Francisco City Hall,58,356,Subscriber,94703
+4302,2138,8/29/2013 11:58,Davis at Jackson,42,8/29/2013 12:33,Market at 4th,76,615,Subscriber,94129
+4646,2542,8/29/2013 15:26,Powell Street BART,39,8/29/2013 16:08,Embarcadero at Folsom,51,555,Customer,94103
+4922,3349,8/29/2013 18:50,Palo Alto Caltrain Station,34,8/29/2013 19:46,Palo Alto Caltrain Station,34,135,Subscriber,94061
+4694,3362,8/29/2013 16:04,Market at Sansome,77,8/29/2013 17:00,Powell Street BART,39,402,Customer,10023
+4135,3492,8/29/2013 10:19,South Van Ness at Market,66,8/29/2013 11:18,San Francisco Caltrain 2 (330 Townsend),69,318,Subscriber,94123
+4388,3582,8/29/2013 12:33,Embarcadero at Sansome,60,8/29/2013 13:33,San Francisco City Hall,58,462,Customer,21144
+4132,3637,8/29/2013 10:17,South Van Ness at Market,66,8/29/2013 11:17,San Francisco Caltrain 2 (330 Townsend),69,327,Subscriber,94124
+4078,3829,8/29/2013 9:31,Redwood City Caltrain Station,22,8/29/2013 10:34,Redwood City Caltrain Station,22,228,Customer,94062
+4709,4116,8/29/2013 16:17,Davis at Jackson,42,8/29/2013 17:26,Davis at Jackson,42,425,Customer,92178
+4572,4331,8/29/2013 14:07,Golden Gate at Polk,59,8/29/2013 15:20,Post at Kearney,47,373,Customer,94109
+4622,4499,8/29/2013 15:00,Market at 4th,76,8/29/2013 16:15,Market at Sansome,77,529,Customer,
+4578,4521,8/29/2013 14:13,San Francisco City Hall,58,8/29/2013 15:29,Townsend at 7th,65,623,Customer,10010
+4577,4524,8/29/2013 14:13,San Francisco City Hall,58,8/29/2013 15:28,Townsend at 7th,65,632,Customer,10010
+4621,4536,8/29/2013 15:00,Market at 4th,76,8/29/2013 16:15,Market at Sansome,77,430,Customer,
+4893,4756,8/29/2013 18:22,Embarcadero at Vallejo,48,8/29/2013 19:41,Embarcadero at Vallejo,48,386,Customer,
+4758,4801,8/29/2013 17:00,Golden Gate at Polk,59,8/29/2013 18:20,Market at 10th,67,635,Customer,94102
+4634,5075,8/29/2013 15:09,Embarcadero at Folsom,51,8/29/2013 16:34,Market at 4th,76,266,Customer,
+4884,5506,8/29/2013 18:12,Harry Bridges Plaza (Ferry Building),50,8/29/2013 19:44,Grant Avenue at Columbus Avenue,73,634,Customer,76102
+4313,5709,8/29/2013 12:06,Temporary Transbay Terminal (Howard at Beale),55,8/29/2013 13:41,Temporary Transbay Terminal (Howard at Beale),55,352,Customer,
+4882,5776,8/29/2013 18:11,Civic Center BART (7th at Market),72,8/29/2013 19:48,Embarcadero at Vallejo,48,571,Customer,
+4669,5983,8/29/2013 15:40,Townsend at 7th,65,8/29/2013 17:20,Townsend at 7th,65,411,Customer,94110
+4603,6095,8/29/2013 14:35,Market at 10th,67,8/29/2013 16:16,South Van Ness at Market,66,448,Customer,
+4166,7138,8/29/2013 10:49,Spear at Folsom,49,8/29/2013 12:48,Spear at Folsom,49,558,Customer,94105
+4565,7148,8/29/2013 14:04,Market at Sansome,77,8/29/2013 16:03,Civic Center BART (7th at Market),72,437,Subscriber,94608
+4639,11118,8/29/2013 15:18,Market at 4th,76,8/29/2013 18:23,Market at 4th,76,433,Customer,
+4637,11272,8/29/2013 15:17,Market at 4th,76,8/29/2013 18:25,Market at 4th,76,377,Customer,
+4528,12280,8/29/2013 13:39,Paseo de San Antonio,7,8/29/2013 17:04,Adobe on Almaden,5,645,Subscriber,94536
+4363,15244,8/29/2013 12:23,Market at 4th,76,8/29/2013 16:37,Powell Street BART,39,434,Customer,
+4193,18192,8/29/2013 11:04,Embarcadero at Vallejo,48,8/29/2013 16:08,Market at Sansome,77,501,Customer,72150
+4190,18240,8/29/2013 11:04,Embarcadero at Vallejo,48,8/29/2013 16:08,Market at Sansome,77,614,Customer,72150
+4225,21612,8/29/2013 11:18,Powell Street BART,39,8/29/2013 17:18,Market at 10th,67,464,Customer,58553
+4663,52698,8/29/2013 15:34,Mountain View City Hall,27,8/30/2013 6:12,Park at Olive,38,150,Subscriber,94301
+4532,84990,8/29/2013 13:43,Market at 4th,76,8/30/2013 13:19,Harry Bridges Plaza (Ferry Building),50,460,Customer,94118
+4521,85385,8/29/2013 13:37,Market at 4th,76,8/30/2013 13:20,Harry Bridges Plaza (Ferry Building),50,390,Customer,94118
+5069,86102,8/29/2013 21:41,Embarcadero at Folsom,51,8/30/2013 21:37,Davis at Jackson,42,269,Customer,94111
+4505,97713,8/29/2013 13:30,Mountain View Caltrain Station,28,8/30/2013 16:38,Mountain View City Hall,27,141,Subscriber,94039
+6115,69,8/30/2013 16:30,2nd at Folsom,62,8/30/2013 16:31,2nd at Folsom,62,633,Subscriber,94107
+5157,75,8/30/2013 8:18,Market at Sansome,77,8/30/2013 8:19,Market at Sansome,77,586,Customer,94105
+5349,76,8/30/2013 10:56,San Jose City Hall,10,8/30/2013 10:57,MLK Library,11,28,Subscriber,95112
+5314,94,8/30/2013 10:44,Market at 10th,67,8/30/2013 10:46,South Van Ness at Market,66,598,Subscriber,94703
+5580,112,8/30/2013 12:52,Mechanics Plaza (Market at Battery),75,8/30/2013 12:54,Market at Sansome,77,341,Subscriber,94107
+5872,125,8/30/2013 15:04,Embarcadero at Bryant,54,8/30/2013 15:06,Embarcadero at Bryant,54,603,Customer,
+5483,129,8/30/2013 12:07,Harry Bridges Plaza (Ferry Building),50,8/30/2013 12:09,Harry Bridges Plaza (Ferry Building),50,487,Customer,98126
+6457,130,8/30/2013 22:37,Market at 4th,76,8/30/2013 22:39,Market at 4th,76,280,Subscriber,94123
+5767,134,8/30/2013 14:14,Commercial at Montgomery,45,8/30/2013 14:17,Commercial at Montgomery,45,520,Customer,
+6393,134,8/30/2013 19:32,South Van Ness at Market,66,8/30/2013 19:34,South Van Ness at Market,66,618,Subscriber,94102
+5947,140,8/30/2013 15:22,South Van Ness at Market,66,8/30/2013 15:25,South Van Ness at Market,66,560,Customer,
+5480,149,8/30/2013 12:05,Temporary Transbay Terminal (Howard at Beale),55,8/30/2013 12:08,Spear at Folsom,49,364,Subscriber,94105
+6266,168,8/30/2013 17:53,Japantown,9,8/30/2013 17:56,Japantown,9,638,Subscriber,95125
+5702,170,8/30/2013 13:43,2nd at Folsom,62,8/30/2013 13:46,2nd at South Park,64,442,Subscriber,94518
+5465,177,8/30/2013 12:00,5th at Howard,57,8/30/2013 12:03,Powell Street BART,39,432,Customer,
+5617,179,8/30/2013 13:12,Spear at Folsom,49,8/30/2013 13:15,Temporary Transbay Terminal (Howard at Beale),55,348,Subscriber,94105
+5476,182,8/30/2013 12:04,Harry Bridges Plaza (Ferry Building),50,8/30/2013 12:07,Davis at Jackson,42,522,Subscriber,94123
+5744,182,8/30/2013 14:00,South Van Ness at Market,66,8/30/2013 14:03,South Van Ness at Market,66,395,Customer,85008
+5543,185,8/30/2013 12:36,South Van Ness at Market,66,8/30/2013 12:39,Market at 10th,67,510,Subscriber,94118
+5282,193,8/30/2013 10:37,St James Park,13,8/30/2013 10:41,San Jose City Hall,10,658,Subscriber,95112
+5462,194,8/30/2013 11:58,Howard at 2nd,63,8/30/2013 12:02,Howard at 2nd,63,310,Customer,94133
+5213,195,8/30/2013 9:47,Civic Center BART (7th at Market),72,8/30/2013 9:50,Market at 10th,67,598,Subscriber,94609
+6191,197,8/30/2013 17:09,Market at 10th,67,8/30/2013 17:13,Civic Center BART (7th at Market),72,409,Customer,94606
+5873,199,8/30/2013 15:05,Embarcadero at Sansome,60,8/30/2013 15:09,Embarcadero at Vallejo,48,520,Customer,
+5550,211,8/30/2013 12:46,Embarcadero at Vallejo,48,8/30/2013 12:50,Davis at Jackson,42,412,Customer,85224
+6117,213,8/30/2013 16:31,2nd at Folsom,62,8/30/2013 16:35,2nd at Folsom,62,633,Subscriber,94107
+5219,214,8/30/2013 9:52,Mechanics Plaza (Market at Battery),75,8/30/2013 9:55,Temporary Transbay Terminal (Howard at Beale),55,518,Subscriber,94105
+6220,216,8/30/2013 17:22,South Van Ness at Market,66,8/30/2013 17:25,Civic Center BART (7th at Market),72,316,Subscriber,94703
+5671,220,8/30/2013 13:28,Townsend at 7th,65,8/30/2013 13:32,San Francisco Caltrain 2 (330 Townsend),69,565,Customer,94118
+5830,220,8/30/2013 14:38,Commercial at Montgomery,45,8/30/2013 14:41,Harry Bridges Plaza (Ferry Building),50,572,Subscriber,94123
+5797,227,8/30/2013 14:27,Market at Sansome,77,8/30/2013 14:31,Steuart at Market,74,513,Subscriber,94115
+6292,229,8/30/2013 18:15,2nd at Folsom,62,8/30/2013 18:18,Market at Sansome,77,272,Customer,94608
+5230,232,8/30/2013 9:58,Harry Bridges Plaza (Ferry Building),50,8/30/2013 10:02,Harry Bridges Plaza (Ferry Building),50,270,Customer,28005
+5426,232,8/30/2013 11:48,San Francisco Caltrain (Townsend at 4th),70,8/30/2013 11:52,2nd at Townsend,61,504,Subscriber,94107
+5460,238,8/30/2013 11:58,Commercial at Montgomery,45,8/30/2013 12:02,Commercial at Montgomery,45,383,Subscriber,94103
+5746,238,8/30/2013 14:03,Paseo de San Antonio,7,8/30/2013 14:07,MLK Library,11,185,Subscriber,95112
+5473,241,8/30/2013 12:04,South Van Ness at Market,66,8/30/2013 12:08,San Francisco City Hall,58,395,Subscriber,94122
+5705,241,8/30/2013 13:46,San Francisco City Hall,58,8/30/2013 13:50,Golden Gate at Polk,59,630,Subscriber,94122
+5133,246,8/30/2013 7:27,Mountain View City Hall,27,8/30/2013 7:31,Mountain View Caltrain Station,28,155,Customer,94302
+5196,246,8/30/2013 9:05,San Francisco Caltrain (Townsend at 4th),70,8/30/2013 9:09,Townsend at 7th,65,288,Customer,95118
+5555,249,8/30/2013 12:47,Market at 10th,67,8/30/2013 12:51,South Van Ness at Market,66,367,Subscriber,94118
+6405,251,8/30/2013 19:49,Townsend at 7th,65,8/30/2013 19:54,San Francisco Caltrain (Townsend at 4th),70,554,Customer,94118
+5372,252,8/30/2013 11:04,2nd at South Park,64,8/30/2013 11:08,2nd at Folsom,62,360,Subscriber,94114
+6234,254,8/30/2013 17:24,Yerba Buena Center of the Arts (3rd @ Howard),68,8/30/2013 17:28,Howard at 2nd,63,368,Customer,94105
+5496,255,8/30/2013 12:14,Beale at Market,56,8/30/2013 12:18,Harry Bridges Plaza (Ferry Building),50,384,Subscriber,94107
+5652,256,8/30/2013 13:21,San Salvador at 1st,8,8/30/2013 13:25,San Pedro Square,6,671,Subscriber,95112
+5651,258,8/30/2013 13:20,South Van Ness at Market,66,8/30/2013 13:24,San Francisco City Hall,58,388,Subscriber,94122
+5229,259,8/30/2013 9:58,Steuart at Market,74,8/30/2013 10:02,Spear at Folsom,49,399,Subscriber,94112
+5255,265,8/30/2013 10:23,Beale at Market,56,8/30/2013 10:27,Mechanics Plaza (Market at Battery),75,439,Subscriber,94703
+5209,266,8/30/2013 9:36,Powell Street BART,39,8/30/2013 9:40,Market at 10th,67,409,Customer,
+5745,266,8/30/2013 14:03,Golden Gate at Polk,59,8/30/2013 14:08,Market at 10th,67,630,Subscriber,94122
+5257,268,8/30/2013 10:27,Mechanics Plaza (Market at Battery),75,8/30/2013 10:32,Market at 4th,76,538,Subscriber,94703
+6283,271,8/30/2013 18:08,Townsend at 7th,65,8/30/2013 18:12,San Francisco Caltrain 2 (330 Townsend),69,338,Subscriber,94133
+5958,273,8/30/2013 15:25,2nd at South Park,64,8/30/2013 15:29,2nd at South Park,64,426,Subscriber,94109
+6285,274,8/30/2013 18:08,Embarcadero at Sansome,60,8/30/2013 18:13,Embarcadero at Sansome,60,285,Subscriber,94597
+6446,280,8/30/2013 21:40,Mountain View Caltrain Station,28,8/30/2013 21:45,Mountain View Caltrain Station,28,165,Subscriber,94041
+5185,282,8/30/2013 8:49,San Francisco Caltrain (Townsend at 4th),70,8/30/2013 8:53,5th at Howard,57,602,Customer,95032
+6304,282,8/30/2013 18:20,Market at 4th,76,8/30/2013 18:24,Powell Street BART,39,337,Customer,
+6448,283,8/30/2013 21:41,Spear at Folsom,49,8/30/2013 21:46,Howard at 2nd,63,611,Subscriber,94105
+6132,284,8/30/2013 16:37,Santa Clara at Almaden,4,8/30/2013 16:42,San Jose Diridon Caltrain Station,2,68,Subscriber,94158
+5612,288,8/30/2013 13:10,St James Park,13,8/30/2013 13:15,San Pedro Square,6,652,Subscriber,95112
+6326,289,8/30/2013 18:38,San Jose Diridon Caltrain Station,2,8/30/2013 18:43,San Jose Diridon Caltrain Station,2,23,Subscriber,95126
+5247,290,8/30/2013 10:15,Steuart at Market,74,8/30/2013 10:20,Beale at Market,56,414,Subscriber,94703
+6218,292,8/30/2013 17:21,Post at Kearney,47,8/30/2013 17:26,Clay at Battery,41,577,Subscriber,94110
+6273,292,8/30/2013 18:04,2nd at Townsend,61,8/30/2013 18:09,San Francisco Caltrain (Townsend at 4th),70,567,Subscriber,94107
+5742,293,8/30/2013 13:59,San Francisco Caltrain 2 (330 Townsend),69,8/30/2013 14:04,Townsend at 7th,65,361,Customer,94118
+6416,296,8/30/2013 20:19,2nd at South Park,64,8/30/2013 20:24,Market at Sansome,77,583,Subscriber,94110
+5675,297,8/30/2013 13:30,Santa Clara at Almaden,4,8/30/2013 13:35,San Jose Diridon Caltrain Station,2,664,Subscriber,95112
+5605,303,8/30/2013 13:08,Paseo de San Antonio,7,8/30/2013 13:13,San Jose Civic Center,3,174,Subscriber,95032
+5399,304,8/30/2013 11:32,San Francisco Caltrain 2 (330 Townsend),69,8/30/2013 11:37,Townsend at 7th,65,474,Subscriber,94117
+6406,304,8/30/2013 19:51,Paseo de San Antonio,7,8/30/2013 19:56,St James Park,13,658,Customer,
+6352,306,8/30/2013 18:58,Civic Center BART (7th at Market),72,8/30/2013 19:03,Civic Center BART (7th at Market),72,586,Subscriber,94114
+6264,307,8/30/2013 17:53,Spear at Folsom,49,8/30/2013 17:58,Steuart at Market,74,512,Subscriber,94112
+6305,307,8/30/2013 18:20,Market at 4th,76,8/30/2013 18:25,Powell Street BART,39,592,Customer,
+5265,311,8/30/2013 10:32,Market at 4th,76,8/30/2013 10:37,Civic Center BART (7th at Market),72,622,Subscriber,94703
+6073,311,8/30/2013 16:19,Market at Sansome,77,8/30/2013 16:24,Yerba Buena Center of the Arts (3rd @ Howard),68,430,Customer,94941
+5248,315,8/30/2013 10:15,Clay at Battery,41,8/30/2013 10:20,Mechanics Plaza (Market at Battery),75,538,Customer,94941
+5730,316,8/30/2013 13:56,Spear at Folsom,49,8/30/2013 14:01,Howard at 2nd,63,364,Customer,
+5194,317,8/30/2013 9:04,San Francisco Caltrain 2 (330 Townsend),69,8/30/2013 9:09,5th at Howard,57,268,Customer,94107
+5207,317,8/30/2013 9:29,2nd at Townsend,61,8/30/2013 9:35,Howard at 2nd,63,310,Subscriber,94107
+6167,317,8/30/2013 16:47,Temporary Transbay Terminal (Howard at Beale),55,8/30/2013 16:52,Harry Bridges Plaza (Ferry Building),50,397,Customer,94611
+6327,317,8/30/2013 18:41,Market at 10th,67,8/30/2013 18:47,Powell Street BART,39,610,Subscriber,94609
+6335,317,8/30/2013 18:43,Civic Center BART (7th at Market),72,8/30/2013 18:49,Civic Center BART (7th at Market),72,560,Customer,90066
+5266,318,8/30/2013 10:34,Market at 4th,76,8/30/2013 10:39,Yerba Buena Center of the Arts (3rd @ Howard),68,266,Subscriber,94110
+5763,322,8/30/2013 14:13,San Mateo County Center,23,8/30/2013 14:19,San Mateo County Center,23,226,Subscriber,94117
+5518,325,8/30/2013 12:19,Mountain View Caltrain Station,28,8/30/2013 12:25,Evelyn Park and Ride,30,155,Customer,94107
+6479,325,8/30/2013 23:51,Harry Bridges Plaza (Ferry Building),50,8/30/2013 23:56,Steuart at Market,74,523,Customer,
+5290,327,8/30/2013 10:38,Market at Sansome,77,8/30/2013 10:44,2nd at Folsom,62,442,Customer,94608
+6118,327,8/30/2013 16:32,South Van Ness at Market,66,8/30/2013 16:37,Civic Center BART (7th at Market),72,560,Subscriber,94597
+6272,328,8/30/2013 18:00,Powell Street BART,39,8/30/2013 18:06,Market at Sansome,77,507,Subscriber,94107
+6419,330,8/30/2013 20:36,Market at 10th,67,8/30/2013 20:41,Market at 4th,76,408,Subscriber,94108
+5499,331,8/30/2013 12:14,Embarcadero at Vallejo,48,8/30/2013 12:19,Embarcadero at Sansome,60,428,Customer,33990
+5191,332,8/30/2013 8:59,Civic Center BART (7th at Market),72,8/30/2013 9:04,South Van Ness at Market,66,323,Subscriber,94115
+5994,333,8/30/2013 15:40,Embarcadero at Sansome,60,8/30/2013 15:45,Embarcadero at Sansome,60,624,Subscriber,94109
+6445,333,8/30/2013 21:37,Civic Center BART (7th at Market),72,8/30/2013 21:42,South Van Ness at Market,66,329,Subscriber,94134
+5212,334,8/30/2013 9:43,Post at Kearney,47,8/30/2013 9:49,Beale at Market,56,359,Subscriber,94110
+6172,334,8/30/2013 16:53,San Jose City Hall,10,8/30/2013 16:59,San Pedro Square,6,35,Subscriber,95112
+5491,335,8/30/2013 12:12,Howard at 2nd,63,8/30/2013 12:18,5th at Howard,57,598,Subscriber,94115
+6359,337,8/30/2013 19:05,Embarcadero at Sansome,60,8/30/2013 19:11,Embarcadero at Sansome,60,529,Subscriber,94111
+5454,341,8/30/2013 11:57,Embarcadero at Bryant,54,8/30/2013 12:03,Harry Bridges Plaza (Ferry Building),50,522,Subscriber,94404
+5501,341,8/30/2013 12:14,Post at Kearney,47,8/30/2013 12:19,2nd at South Park,64,583,Subscriber,94110
+5776,343,8/30/2013 14:17,5th at Howard,57,8/30/2013 14:23,San Francisco Caltrain (Townsend at 4th),70,318,Customer,95032
+5276,344,8/30/2013 10:35,Beale at Market,56,8/30/2013 10:41,Post at Kearney,47,359,Subscriber,94110
+5516,347,8/30/2013 12:18,Beale at Market,56,8/30/2013 12:24,Temporary Transbay Terminal (Howard at Beale),55,587,Subscriber,94965
+6176,347,8/30/2013 16:57,Embarcadero at Vallejo,48,8/30/2013 17:03,Embarcadero at Sansome,60,520,Subscriber,94123
+6296,348,8/30/2013 18:16,San Salvador at 1st,8,8/30/2013 18:22,San Jose Civic Center,3,680,Subscriber,95125
+6038,350,8/30/2013 16:08,Clay at Battery,41,8/30/2013 16:14,Harry Bridges Plaza (Ferry Building),50,425,Subscriber,94111
+5168,352,8/30/2013 8:27,South Van Ness at Market,66,8/30/2013 8:33,Powell Street BART,39,409,Subscriber,94117
+5931,352,8/30/2013 15:19,Post at Kearney,47,8/30/2013 15:24,Harry Bridges Plaza (Ferry Building),50,483,Subscriber,94901
+5694,355,8/30/2013 13:36,San Pedro Square,6,8/30/2013 13:42,San Salvador at 1st,8,671,Subscriber,95112
+5492,356,8/30/2013 12:09,Davis at Jackson,42,8/30/2013 12:15,Grant Avenue at Columbus Avenue,73,425,Subscriber,94129
+6477,356,8/30/2013 23:51,Harry Bridges Plaza (Ferry Building),50,8/30/2013 23:56,Steuart at Market,74,350,Customer,70129
+6284,359,8/30/2013 18:08,San Jose City Hall,10,8/30/2013 18:14,San Salvador at 1st,8,680,Subscriber,95125
+5798,362,8/30/2013 14:28,Embarcadero at Bryant,54,8/30/2013 14:34,Steuart at Market,74,285,Subscriber,94109
+5425,364,8/30/2013 11:48,Powell Street BART,39,8/30/2013 11:54,San Francisco Caltrain 2 (330 Townsend),69,434,Subscriber,94102
+5288,368,8/30/2013 10:38,Civic Center BART (7th at Market),72,8/30/2013 10:44,Market at 10th,67,571,Subscriber,94703
+6476,370,8/30/2013 23:50,Harry Bridges Plaza (Ferry Building),50,8/30/2013 23:56,Steuart at Market,74,467,Customer,70129
+5117,371,8/30/2013 5:16,Powell Street BART,39,8/30/2013 5:23,San Francisco Caltrain 2 (330 Townsend),69,432,Customer,
+5618,372,8/30/2013 13:12,San Pedro Square,6,8/30/2013 13:19,Paseo de San Antonio,7,657,Subscriber,95035
+5600,375,8/30/2013 13:07,Embarcadero at Sansome,60,8/30/2013 13:13,Clay at Battery,41,607,Customer,94107
+5720,375,8/30/2013 13:54,Commercial at Montgomery,45,8/30/2013 14:00,Market at 4th,76,529,Subscriber,94109
+5868,375,8/30/2013 15:02,South Van Ness at Market,66,8/30/2013 15:08,Powell Street BART,39,316,Subscriber,94117
+5879,375,8/30/2013 15:09,Post at Kearney,47,8/30/2013 15:15,Post at Kearney,47,448,Subscriber,94030
+6438,377,8/30/2013 21:16,Beale at Market,56,8/30/2013 21:22,Spear at Folsom,49,611,Subscriber,94105
+5909,378,8/30/2013 15:14,2nd at Townsend,61,8/30/2013 15:20,Market at Sansome,77,366,Subscriber,94115
+5834,381,8/30/2013 14:43,San Jose Civic Center,3,8/30/2013 14:49,Adobe on Almaden,5,654,Subscriber,95032
+6212,385,8/30/2013 17:18,Redwood City Medical Center,26,8/30/2013 17:24,Redwood City Caltrain Station,22,249,Subscriber,94041
+6307,387,8/30/2013 18:21,San Pedro Square,6,8/30/2013 18:27,Paseo de San Antonio,7,82,Customer,95112
+6072,389,8/30/2013 16:17,Market at Sansome,77,8/30/2013 16:24,Yerba Buena Center of the Arts (3rd @ Howard),68,414,Customer,94105
+5604,390,8/30/2013 13:08,Harry Bridges Plaza (Ferry Building),50,8/30/2013 13:15,Embarcadero at Bryant,54,470,Subscriber,94404
+5940,390,8/30/2013 15:21,Embarcadero at Vallejo,48,8/30/2013 15:27,Embarcadero at Sansome,60,624,Customer,94611
+6358,391,8/30/2013 19:04,Embarcadero at Sansome,60,8/30/2013 19:11,Embarcadero at Sansome,60,324,Customer,94111
+6398,392,8/30/2013 19:36,Evelyn Park and Ride,30,8/30/2013 19:42,Mountain View Caltrain Station,28,151,Subscriber,94040
+6125,393,8/30/2013 16:35,2nd at Folsom,62,8/30/2013 16:42,San Francisco Caltrain (Townsend at 4th),70,633,Subscriber,94107
+5127,394,8/30/2013 7:07,Rengstorff Avenue / California Street,33,8/30/2013 7:14,San Antonio Caltrain Station,29,219,Subscriber,94040
+5549,395,8/30/2013 12:43,Harry Bridges Plaza (Ferry Building),50,8/30/2013 12:50,Mechanics Plaza (Market at Battery),75,416,Subscriber,94107
+6397,395,8/30/2013 19:36,Evelyn Park and Ride,30,8/30/2013 19:42,Mountain View Caltrain Station,28,48,Subscriber,94040
+6442,396,8/30/2013 21:24,Spear at Folsom,49,8/30/2013 21:31,Beale at Market,56,568,Subscriber,94110
+5935,398,8/30/2013 15:19,Clay at Battery,41,8/30/2013 15:26,Commercial at Montgomery,45,544,Subscriber,94102
+5419,399,8/30/2013 11:40,South Van Ness at Market,66,8/30/2013 11:47,Golden Gate at Polk,59,508,Subscriber,94114
+5154,401,8/30/2013 8:16,2nd at Townsend,61,8/30/2013 8:23,Market at Sansome,77,290,Subscriber,94107
+5869,401,8/30/2013 15:02,Embarcadero at Sansome,60,8/30/2013 15:09,Embarcadero at Vallejo,48,400,Customer,
+5925,401,8/30/2013 15:17,Embarcadero at Sansome,60,8/30/2013 15:24,Harry Bridges Plaza (Ferry Building),50,270,Customer,85327
+5681,403,8/30/2013 13:32,Beale at Market,56,8/30/2013 13:39,Market at 4th,76,477,Subscriber,94110
+5374,405,8/30/2013 11:07,Japantown,9,8/30/2013 11:14,Japantown,9,653,Subscriber,95112
+5877,405,8/30/2013 15:09,2nd at South Park,64,8/30/2013 15:16,2nd at Folsom,62,633,Subscriber,94114
+6216,406,8/30/2013 17:21,Franklin at Maple,21,8/30/2013 17:28,Broadway at Main,25,262,Subscriber,94063
+5440,408,8/30/2013 11:53,Redwood City Caltrain Station,22,8/30/2013 11:59,Redwood City Medical Center,26,308,Subscriber,94041
+5939,411,8/30/2013 15:20,Post at Kearney,47,8/30/2013 15:27,Post at Kearney,47,448,Subscriber,94030
+5418,412,8/30/2013 11:40,South Van Ness at Market,66,8/30/2013 11:47,Golden Gate at Polk,59,614,Subscriber,94123
+6453,414,8/30/2013 22:13,Market at Sansome,77,8/30/2013 22:20,Harry Bridges Plaza (Ferry Building),50,583,Customer,94510
+6174,415,8/30/2013 16:53,Powell at Post (Union Square),71,8/30/2013 17:00,Commercial at Montgomery,45,393,Subscriber,94117
+6314,415,8/30/2013 18:26,San Jose City Hall,10,8/30/2013 18:33,San Salvador at 1st,8,30,Subscriber,95112
+5301,416,8/30/2013 10:41,Golden Gate at Polk,59,8/30/2013 10:48,Powell Street BART,39,506,Subscriber,94109
+6011,418,8/30/2013 15:53,Paseo de San Antonio,7,8/30/2013 16:00,San Pedro Square,6,657,Customer,
+6313,419,8/30/2013 18:26,San Jose City Hall,10,8/30/2013 18:33,San Salvador at 1st,8,679,Subscriber,95112
+5924,420,8/30/2013 15:17,Embarcadero at Sansome,60,8/30/2013 15:24,Harry Bridges Plaza (Ferry Building),50,539,Customer,22201
+5525,422,8/30/2013 12:21,Park at Olive,38,8/30/2013 12:28,Park at Olive,38,66,Customer,94920
+6010,425,8/30/2013 15:53,Paseo de San Antonio,7,8/30/2013 16:00,San Pedro Square,6,639,Customer,
+5118,430,8/30/2013 6:28,Steuart at Market,74,8/30/2013 6:35,Embarcadero at Bryant,54,603,Subscriber,94109
+5466,434,8/30/2013 12:00,Market at 4th,76,8/30/2013 12:08,Harry Bridges Plaza (Ferry Building),50,562,Subscriber,94110
+5169,437,8/30/2013 8:28,San Jose Diridon Caltrain Station,2,8/30/2013 8:35,Santa Clara at Almaden,4,664,Subscriber,94158
+6322,438,8/30/2013 18:36,San Francisco Caltrain (Townsend at 4th),70,8/30/2013 18:43,2nd at Townsend,61,633,Subscriber,94107
+6386,438,8/30/2013 19:24,San Francisco Caltrain (Townsend at 4th),70,8/30/2013 19:31,2nd at South Park,64,404,Customer,94103
+6378,440,8/30/2013 19:20,Golden Gate at Polk,59,8/30/2013 19:27,Market at 4th,76,615,Subscriber,94608
+6455,441,8/30/2013 22:31,San Pedro Square,6,8/30/2013 22:39,Japantown,9,644,Subscriber,95112
+5130,442,8/30/2013 7:16,Harry Bridges Plaza (Ferry Building),50,8/30/2013 7:24,Post at Kearney,47,286,Subscriber,94901
+5488,444,8/30/2013 12:10,San Francisco City Hall,58,8/30/2013 12:18,Market at 4th,76,395,Subscriber,94122
+5592,444,8/30/2013 13:03,Steuart at Market,74,8/30/2013 13:11,Post at Kearney,47,483,Subscriber,94123
+5171,445,8/30/2013 8:29,Civic Center BART (7th at Market),72,8/30/2013 8:36,Powell at Post (Union Square),71,623,Subscriber,94103
+5794,446,8/30/2013 14:22,Spear at Folsom,49,8/30/2013 14:30,Harry Bridges Plaza (Ferry Building),50,574,Customer,
+6277,446,8/30/2013 18:06,San Antonio Caltrain Station,29,8/30/2013 18:13,Rengstorff Avenue / California Street,33,124,Subscriber,94043
+6456,447,8/30/2013 22:35,2nd at Townsend,61,8/30/2013 22:43,Townsend at 7th,65,312,Customer,94110
+5590,449,8/30/2013 13:00,Redwood City Public Library,24,8/30/2013 13:07,San Mateo County Center,23,233,Subscriber,94402
+5522,450,8/30/2013 12:20,Post at Kearney,47,8/30/2013 12:27,Steuart at Market,74,483,Subscriber,94123
+5487,452,8/30/2013 12:10,Post at Kearney,47,8/30/2013 12:18,Powell Street BART,39,359,Subscriber,94043
+5138,453,8/30/2013 7:44,South Van Ness at Market,66,8/30/2013 7:51,Market at 4th,76,622,Customer,
+5206,455,8/30/2013 9:21,Steuart at Market,74,8/30/2013 9:29,2nd at Townsend,61,461,Customer,94608
+5388,457,8/30/2013 11:21,Powell Street BART,39,8/30/2013 11:28,San Francisco Caltrain 2 (330 Townsend),69,474,Customer,94110
+5850,457,8/30/2013 14:56,St James Park,13,8/30/2013 15:03,Paseo de San Antonio,7,639,Customer,
+5396,459,8/30/2013 11:30,South Van Ness at Market,66,8/30/2013 11:38,Market at 4th,76,562,Subscriber,94122
+5542,461,8/30/2013 12:35,South Van Ness at Market,66,8/30/2013 12:43,Powell Street BART,39,375,Subscriber,94597
+6348,461,8/30/2013 18:53,2nd at Townsend,61,8/30/2013 19:00,Post at Kearney,47,311,Subscriber,94133
+5180,462,8/30/2013 8:41,San Jose Diridon Caltrain Station,2,8/30/2013 8:49,San Pedro Square,6,675,Customer,94577
+5503,463,8/30/2013 12:16,Embarcadero at Sansome,60,8/30/2013 12:23,Steuart at Market,74,273,Subscriber,94122
+6371,466,8/30/2013 19:18,Market at 4th,76,8/30/2013 19:25,San Francisco Caltrain (Townsend at 4th),70,359,Customer,94118
+5792,467,8/30/2013 14:20,Commercial at Montgomery,45,8/30/2013 14:28,Steuart at Market,74,579,Customer,
+5848,468,8/30/2013 14:55,St James Park,13,8/30/2013 15:03,Paseo de San Antonio,7,658,Customer,
+5420,471,8/30/2013 11:40,Market at Sansome,77,8/30/2013 11:48,Grant Avenue at Columbus Avenue,73,585,Customer,94122
+5412,478,8/30/2013 11:36,San Salvador at 1st,8,8/30/2013 11:44,San Pedro Square,6,180,Subscriber,95112
+5547,479,8/30/2013 12:42,2nd at Townsend,61,8/30/2013 12:50,Harry Bridges Plaza (Ferry Building),50,470,Customer,94608
+5741,480,8/30/2013 13:58,Howard at 2nd,63,8/30/2013 14:06,Commercial at Montgomery,45,579,Subscriber,94103
+5764,481,8/30/2013 14:14,Mechanics Plaza (Market at Battery),75,8/30/2013 14:22,5th at Howard,57,503,Customer,94103
+5774,481,8/30/2013 14:16,South Van Ness at Market,66,8/30/2013 14:24,South Van Ness at Market,66,560,Subscriber,94612
+6338,485,8/30/2013 18:46,Embarcadero at Sansome,60,8/30/2013 18:54,Harry Bridges Plaza (Ferry Building),50,277,Customer,
+6447,485,8/30/2013 21:41,San Francisco Caltrain 2 (330 Townsend),69,8/30/2013 21:49,Powell Street BART,39,289,Subscriber,94102
+5789,486,8/30/2013 14:20,Commercial at Montgomery,45,8/30/2013 14:28,Steuart at Market,74,520,Customer,
+5842,486,8/30/2013 14:48,Market at 10th,67,8/30/2013 14:56,Powell Street BART,39,602,Customer,94523
+6345,486,8/30/2013 18:50,Mechanics Plaza (Market at Battery),75,8/30/2013 18:58,Embarcadero at Bryant,54,470,Subscriber,94110
+6299,487,8/30/2013 18:17,Market at Sansome,77,8/30/2013 18:25,Spear at Folsom,49,507,Subscriber,94105
+5377,489,8/30/2013 11:12,Market at 4th,76,8/30/2013 11:20,Harry Bridges Plaza (Ferry Building),50,536,Customer,93619
+5376,490,8/30/2013 11:12,Market at 4th,76,8/30/2013 11:20,Harry Bridges Plaza (Ferry Building),50,606,Customer,93619
+5190,492,8/30/2013 8:57,Davis at Jackson,42,8/30/2013 9:05,Commercial at Montgomery,45,529,Customer,94111
+5210,493,8/30/2013 9:36,2nd at Folsom,62,8/30/2013 9:44,Clay at Battery,41,360,Customer,94105
+5442,494,8/30/2013 11:53,2nd at Townsend,61,8/30/2013 12:01,Harry Bridges Plaza (Ferry Building),50,386,Subscriber,94107
+5591,494,8/30/2013 13:01,MLK Library,11,8/30/2013 13:10,MLK Library,11,38,Customer,95110
+5122,495,8/30/2013 6:41,2nd at Townsend,61,8/30/2013 6:50,Embarcadero at Folsom,51,292,Subscriber,94107
+5136,495,8/30/2013 7:38,Grant Avenue at Columbus Avenue,73,8/30/2013 7:46,Spear at Folsom,49,608,Subscriber,94133
+5240,497,8/30/2013 10:02,South Van Ness at Market,66,8/30/2013 10:10,South Van Ness at Market,66,323,Subscriber,94612
+5199,498,8/30/2013 9:10,Market at Sansome,77,8/30/2013 9:19,2nd at South Park,64,535,Customer,94105
+5933,498,8/30/2013 15:19,Golden Gate at Polk,59,8/30/2013 15:27,San Francisco Caltrain (Townsend at 4th),70,375,Customer,94010
+6179,498,8/30/2013 16:59,Post at Kearney,47,8/30/2013 17:08,Grant Avenue at Columbus Avenue,73,338,Customer,94619
+6245,498,8/30/2013 17:30,Embarcadero at Bryant,54,8/30/2013 17:38,San Francisco Caltrain (Townsend at 4th),70,404,Customer,94043
+5749,499,8/30/2013 14:11,Clay at Battery,41,8/30/2013 14:19,2nd at Folsom,62,272,Customer,94105
+6403,499,8/30/2013 19:48,Paseo de San Antonio,7,8/30/2013 19:56,St James Park,13,676,Customer,95112
+6004,506,8/30/2013 15:47,San Francisco City Hall,58,8/30/2013 15:55,Market at 4th,76,511,Customer,94103
+6008,508,8/30/2013 15:49,Beale at Market,56,8/30/2013 15:58,Post at Kearney,47,338,Subscriber,94109
+5217,509,8/30/2013 9:49,Howard at 2nd,63,8/30/2013 9:58,Commercial at Montgomery,45,383,Customer,94133
+6402,509,8/30/2013 19:48,Paseo de San Antonio,7,8/30/2013 19:56,St James Park,13,675,Customer,
+5125,511,8/30/2013 6:59,Powell Street BART,39,8/30/2013 7:08,Spear at Folsom,49,339,Customer,94109
+6207,511,8/30/2013 17:13,Clay at Battery,41,8/30/2013 17:22,Market at 4th,76,337,Customer,85224
+6330,511,8/30/2013 18:42,Howard at 2nd,63,8/30/2013 18:51,Civic Center BART (7th at Market),72,270,Customer,94702
+6337,511,8/30/2013 18:46,San Antonio Caltrain Station,29,8/30/2013 18:54,Rengstorff Avenue / California Street,33,112,Subscriber,94040
+5712,512,8/30/2013 13:53,Powell Street BART,39,8/30/2013 14:01,South Van Ness at Market,66,560,Subscriber,94117
+6306,514,8/30/2013 18:20,San Francisco Caltrain 2 (330 Townsend),69,8/30/2013 18:29,Howard at 2nd,63,270,Customer,94702
+5134,515,8/30/2013 7:32,Townsend at 7th,65,8/30/2013 7:41,South Van Ness at Market,66,409,Subscriber,94612
+5528,519,8/30/2013 12:24,2nd at South Park,64,8/30/2013 12:33,Post at Kearney,47,287,Subscriber,94110
+5628,522,8/30/2013 13:14,Powell Street BART,39,8/30/2013 13:22,South Van Ness at Market,66,432,Subscriber,94597
+5261,527,8/30/2013 10:28,San Francisco Caltrain 2 (330 Townsend),69,8/30/2013 10:37,2nd at Townsend,61,487,Customer,85327
+5920,527,8/30/2013 15:16,Market at 4th,76,8/30/2013 15:25,San Francisco City Hall,58,508,Customer,94103
+5536,528,8/30/2013 12:29,Golden Gate at Polk,59,8/30/2013 12:38,South Van Ness at Market,66,388,Subscriber,94114
+5595,528,8/30/2013 13:05,Beale at Market,56,8/30/2013 13:14,2nd at South Park,64,557,Customer,
+6454,528,8/30/2013 22:20,Grant Avenue at Columbus Avenue,73,8/30/2013 22:29,Market at Sansome,77,332,Customer,94619
+5936,531,8/30/2013 15:19,Temporary Transbay Terminal (Howard at Beale),55,8/30/2013 15:28,Harry Bridges Plaza (Ferry Building),50,363,Customer,94903
+6317,532,8/30/2013 18:30,Temporary Transbay Terminal (Howard at Beale),55,8/30/2013 18:39,Market at 4th,76,355,Customer,94109
+5822,534,8/30/2013 14:34,Market at 4th,76,8/30/2013 14:42,San Francisco City Hall,58,511,Subscriber,94117
+6303,534,8/30/2013 18:18,Commercial at Montgomery,45,8/30/2013 18:27,Powell Street BART,39,395,Subscriber,94117
+6430,534,8/30/2013 21:08,2nd at Townsend,61,8/30/2013 21:17,Townsend at 7th,65,443,Customer,94103
+5162,536,8/30/2013 8:24,San Francisco Caltrain (Townsend at 4th),70,8/30/2013 8:33,Embarcadero at Folsom,51,379,Subscriber,94133
+5369,539,8/30/2013 11:01,Paseo de San Antonio,7,8/30/2013 11:10,Paseo de San Antonio,7,649,Customer,95123
+6401,539,8/30/2013 19:47,Paseo de San Antonio,7,8/30/2013 19:56,St James Park,13,143,Customer,
+6421,539,8/30/2013 20:38,San Francisco City Hall,58,8/30/2013 20:47,San Francisco City Hall,58,519,Customer,94102
+5140,540,8/30/2013 7:52,Steuart at Market,74,8/30/2013 8:01,5th at Howard,57,318,Customer,94501
+5328,540,8/30/2013 10:47,Steuart at Market,74,8/30/2013 10:56,2nd at Townsend,61,436,Subscriber,94107
+5200,544,8/30/2013 9:13,Post at Kearney,47,8/30/2013 9:22,Market at 10th,67,507,Subscriber,94597
+6256,545,8/30/2013 17:43,South Van Ness at Market,66,8/30/2013 17:52,Powell Street BART,39,617,Subscriber,94117
+5534,547,8/30/2013 12:29,Golden Gate at Polk,59,8/30/2013 12:38,South Van Ness at Market,66,572,Subscriber,94123
+6046,549,8/30/2013 16:10,Embarcadero at Bryant,54,8/30/2013 16:19,Harry Bridges Plaza (Ferry Building),50,337,Subscriber,94105
+6428,551,8/30/2013 21:05,Powell Street BART,39,8/30/2013 21:14,South Van Ness at Market,66,376,Subscriber,94117
+6127,555,8/30/2013 16:36,South Van Ness at Market,66,8/30/2013 16:45,Townsend at 7th,65,473,Subscriber,94107
+6251,555,8/30/2013 17:39,Grant Avenue at Columbus Avenue,73,8/30/2013 17:48,Market at Sansome,77,523,Customer,94133
+5707,556,8/30/2013 13:48,San Francisco Caltrain (Townsend at 4th),70,8/30/2013 13:58,5th at Howard,57,365,Customer,15238

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,13 +44,11 @@ CSV.foreach('db/csv/station.csv', headers: true) do |row|
 end
 
 
-CSV.foreach('db/csv/trip.csv', headers: true).with_index do |row, index|
-  break if index >= 1000
+CSV.foreach('db/csv/trip-trunc.csv', headers: true) do |row|
   row["start_date"] = Date.strptime(row["start_date"], '%m/%d/%Y %k:%M')
   row["end_date"] =  Date.strptime(row["end_date"], '%m/%d/%Y %k:%M')
   row["zip_code"] = zip_cleaner(row["zip_code"])
   Trip.create!(row.to_h)
-  puts "Created trip #{index + 1}"
 end
 
 CSV.foreach('db/csv/weather.csv', headers: true) do |row|

--- a/db/truncate_csv.rb
+++ b/db/truncate_csv.rb
@@ -1,0 +1,39 @@
+require 'csv'
+require 'pry'
+
+# def zip_cleaner(zip)
+#   if zip
+#     zip.to_s[0, 5]
+#   else
+#     "00000"
+#   end
+# end
+
+# csv = CSV.open('db/csv-truncated/trip-trunc.csv')
+
+CSV.open('db/csv-truncated/trip-trunc.csv', "a+") do |csv|
+  csv << ["id","duration","start_date","start_station_name","start_station_id","end_date","end_station_name","end_station_id","bike_id","subscription_type","zip_code"]
+end
+
+CSV.foreach('db/csv/trip.csv', headers: true).with_index do |row, index|
+  next if index.zero?
+  break if index >= 1000
+  CSV.open('db/csv-truncated/trip-trunc.csv', "a+") do |csv|
+    csv << [row["id"],row["duration"],row["start_date"],row["start_station_name"],row["start_station_id"],row["end_date"],row["end_station_name"],row["end_station_id"],row["bike_id"],row["subscription_type"],row["zip_code"]]
+  end
+end
+#
+#
+# CSV.foreach('db/csv/trip.csv', headers: true).with_index do |row, index|
+#   break if index >= 1000
+#   row["start_date"] = Date.strptime(row["start_date"], '%m/%d/%Y %k:%M')
+#   row["end_date"] =  Date.strptime(row["end_date"], '%m/%d/%Y %k:%M')
+#   row["zip_code"] = zip_cleaner(row["zip_code"])
+#   Trip.create!(row.to_h)
+#   puts "Created trip #{index + 1}"
+# end
+#
+# CSV.foreach('db/csv/weather.csv', headers: true) do |row|
+#   row["date"] = Date.strptime(row["date"], '%m/%d/%Y')
+#   Condition.create!(row.to_h)
+# end


### PR DESCRIPTION
Changes proposed in this pull request:  
- This adds a rb file that can truncate (write) to a new csv file. This is only needed for Trips.csv as that's the only one we were limiting. With this change, we can leave the csv files on github so we don't have to gitignore them or add them and remove them for heroku


@adam-conway @anubiskhan @vadlusk @agpiermarini   
