### PR TITLE
Visitor permissions/adam c

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,8 @@ class ApplicationController < ActionController::Base
   helper_method :current_user, :current_admin?
   before_action :set_cart
 
-  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+  rescue_from ActiveRecord::RecordNotFound, with: :error
+  rescue_from NoMethodError, with: :error
 
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
@@ -17,7 +18,7 @@ class ApplicationController < ActionController::Base
     @cart ||= Cart.new(session[:cart])
   end
 
-  def record_not_found
+  def error
     render file: '/public/404'
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   helper_method :current_user, :current_admin?
   before_action :set_cart
 
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
@@ -13,5 +15,9 @@ class ApplicationController < ActionController::Base
 
   def set_cart
     @cart ||= Cart.new(session[:cart])
+  end
+
+  def record_not_found
+    render file: '/public/404'
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -32,6 +32,7 @@ class OrdersController < ApplicationController
     end
 
     def require_correct_user
+      return render file: 'public/404' if current_user.nil?
       render file: 'public/404' unless current_user.id == @order.id || current_admin?
     end
 end

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -50,7 +50,7 @@
     <% if current_user %>
       <%= button_to "Checkout", orders_path(user_id: current_user.id, cart_items: @cart.contents), method: :post %>
     <% else %>
-      <%= button_to "Checkout", login_path %>
+      <%= button_to "Checkout", login_path, method: :get %>
     <% end %>
   </div>
   <% end %>

--- a/app/views/stations/show.html.erb
+++ b/app/views/stations/show.html.erb
@@ -21,7 +21,7 @@
       <% end %>
     </div>
   </div>
-  <% if current_user && @station.start_trips.count >= 1 %>
+  <% if @station.start_trips.count >= 1 %>
     <div class="card-container">
       <div class="card-info" id="station-show">
         <p>Rides started at this station: <%= @station.num_rides_started %></p>

--- a/app/views/trips_dashboard/index.html.erb
+++ b/app/views/trips_dashboard/index.html.erb
@@ -10,7 +10,7 @@
     <div class="dashboard-section">
       <div class="dashboard-info duration">
         <h1>Duration</h1>
-        <h3>Average Trip Duration: <%= @trips.average_duration %> centuries</h3>
+        <h3>Average Trip Duration: <%= @trips.average_duration.to_f/31540000000 %></h3>
       </div>
       <div class="dashboard-info longest-trip">
         <h1>Longest Trip</h1>

--- a/app/views/trips_dashboard/index.html.erb
+++ b/app/views/trips_dashboard/index.html.erb
@@ -10,7 +10,7 @@
     <div class="dashboard-section">
       <div class="dashboard-info duration">
         <h1>Duration</h1>
-        <h3>Average Trip Duration: <%= @trips.average_duration.to_f/31540000000 %></h3>
+        <h3>Average Trip Duration: <%= @trips.average_duration %></h3>
       </div>
       <div class="dashboard-info longest-trip">
         <h1>Longest Trip</h1>

--- a/spec/features/visitor/orders/visitor_cannot_access_another_users_order_spec.rb
+++ b/spec/features/visitor/orders/visitor_cannot_access_another_users_order_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'user sees all conditions' do
+  scenario 'and all their attributes' do
+    order = create(:order)
+    accessory1 = create(:accessory)
+    accessory2 = create(:accessory)
+    accessory3 = create(:accessory)
+    create(:order_accessory, accessory_id: accessory1.id, order_id: order.id)
+    create(:order_accessory, accessory_id: accessory2.id, order_id: order.id)
+    create(:order_accessory, accessory_id: accessory3.id, order_id: order.id)
+
+    visit order_path(order)
+    save_and_open_page
+
+    expect(page).to_not have_content(accessory1.title)
+    expect(page).to_not have_content(accessory2.title)
+    expect(page).to_not have_content(accessory3.title)
+  end
+end

--- a/spec/features/visitor/orders/visitor_cannot_access_another_users_order_spec.rb
+++ b/spec/features/visitor/orders/visitor_cannot_access_another_users_order_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-describe 'user sees all conditions' do
-  scenario 'and all their attributes' do
+describe 'visitor goes to restricted page' do
+  scenario 'tries to go to order page' do
     order = create(:order)
     accessory1 = create(:accessory)
     accessory2 = create(:accessory)
@@ -11,10 +11,17 @@ describe 'user sees all conditions' do
     create(:order_accessory, accessory_id: accessory3.id, order_id: order.id)
 
     visit order_path(order)
-    save_and_open_page
 
     expect(page).to_not have_content(accessory1.title)
     expect(page).to_not have_content(accessory2.title)
     expect(page).to_not have_content(accessory3.title)
+  end
+  scenario 'tries to go to order page' do
+    user = create(:user)
+
+    visit edit_user_path(user)
+    expect(page).to_not have_content("Username")
+    expect(page).to_not have_content("Email")
+    expect(page).to_not have_content("Password")
   end
 end

--- a/spec/features/visitor/visitor_cant_access_new_and_edit_pages_spec.rb
+++ b/spec/features/visitor/visitor_cant_access_new_and_edit_pages_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe 'visitor goes to restricted page' do
+  scenario 'tries to visit admin trip new & edit' do
+    trip = create(:trip)
+
+    visit new_admin_trip_path
+    expect(page).to_not have_content("Duration")
+    expect(page).to_not have_content("Start station")
+    expect(page).to_not have_content("End date")
+
+    visit edit_admin_trip_path(trip)
+    expect(page).to_not have_content("Duration")
+    expect(page).to_not have_content("Start station")
+    expect(page).to_not have_content("End date")
+  end
+  scenario 'tries to visit admin trip new & edit' do
+    condition = create(:condition)
+
+    visit new_admin_condition_path
+    expect(page).to_not have_content("Max temperature f")
+    expect(page).to_not have_content("Min temperature f")
+
+    visit edit_admin_condition_path(condition)
+    expect(page).to_not have_content("Max temperature f")
+    expect(page).to_not have_content("Min temperature f")
+  end
+  scenario 'tries to admin trip new & edit' do
+    station = create(:station)
+
+    visit new_admin_station_path
+    expect(page).to_not have_content("Installation date")
+    expect(page).to_not have_content("Dock count")
+    expect(page).to_not have_content("City")
+
+    visit edit_admin_station_path(station)
+    expect(page).to_not have_content("Installation date")
+    expect(page).to_not have_content("Dock count")
+    expect(page).to_not have_content("City")
+  end
+  scenario 'tries to admin trip new & edit' do
+    accessory = create(:accessory)
+
+    visit new_admin_accessory_path
+    expect(page).to_not have_content("Title")
+    expect(page).to_not have_content("Description")
+    expect(page).to_not have_content("Image url")
+
+    visit edit_admin_accessory_path(accessory)
+    expect(page).to_not have_content("Title")
+    expect(page).to_not have_content("Description")
+    expect(page).to_not have_content("Image url")
+  end
+end


### PR DESCRIPTION
Changes proposed in this pull request:  
- This adds in protections for pages that visitors should not be able to visit (such as users orders or admin only features)
- Also to keep consistent, I took out the logic in the station show that was preventing visitors from seeing analysis on a station show page

connect to #19 
@adam-conway @anubiskhan @vadlusk @agpiermarini   
